### PR TITLE
Issue 22: Switch to Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keikoproj/upgrade-manager
 
-go 1.12
+go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.20.19

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=


### PR DESCRIPTION
Changes done:
- Update Go modules
- Migrate to Go 1.13.1

What was done:

```
# Use a new GOPATH
export GOPATH=$(mktemp -d)

# Update the Go modules
go mod tidy

# Make all
make all
```

How to test:
The build and all the validations done with `make all` are done without error.

Comments:
There was a `go.mod` file not updated so I think the migration to Go modules was previously done. I just update the latest modules and set Go 1.13 because there are some improvements and security fixes.
