### PR TITLE
Fix #30 and release v0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.3-dev
+VERSION=0.3
 # Image URL to use all building/pushing image targets
 IMG ?= keikoproj/rolling-upgrade-controller:${VERSION}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
@@ -43,7 +43,6 @@ vet:
 
 # Generate code
 generate: controller-gen
-	$(CONTROLLER_GEN) --help
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths=./api/...
 
 # Build the docker image

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: keikoproj/rolling-upgrade-controller:0.2-dev
+      - image: keikoproj/rolling-upgrade-controller:0.3
         name: manager

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/keikoproj/upgrade-manager
 go 1.13
 
 require (
-	github.com/aws/aws-sdk-go v1.25.42
+	github.com/aws/aws-sdk-go v1.25.0
 	github.com/go-logr/logr v0.1.0
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/json-iterator/go v1.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,6 @@ github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 h1:Kn3rqvbUFqSe
 github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30/go.mod h1:4AJxUpXUhv4N+ziTvIcWWXgeorXpxPZOfk9HdEVr96M=
 github.com/aws/aws-sdk-go v1.25.0 h1:MyXUdCesJLBvSSKYcaKeeEwxNUwUpG6/uqVYeH/Zzfo=
 github.com/aws/aws-sdk-go v1.25.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.25.33 h1:8muvpP+Bq5e0CDkM9PDZ6tN74fVUq5v3zSCRaZ93ykM=
-github.com/aws/aws-sdk-go v1.25.33/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.25.42 h1:TTsk8HoF5sIq/i5jTjHmY2t3g+b6EiAyiolw7p50UBY=
-github.com/aws/aws-sdk-go v1.25.42/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/log/go.mod
+++ b/pkg/log/go.mod
@@ -3,6 +3,6 @@ module github.com/keikoproj/upgrade-manager/pkg/log
 go 1.13
 
 require (
-	github.com/aws/aws-sdk-go v1.25.42
+	github.com/aws/aws-sdk-go v1.25.0
 	github.com/sirupsen/logrus v1.4.2
 )

--- a/pkg/log/retry_logger.go
+++ b/pkg/log/retry_logger.go
@@ -38,7 +38,7 @@ func (l RetryLogger) RetryRules(r *request.Request) time.Duration {
 	} else {
 		err = fmt.Sprintf("%d %s", r.HTTPResponse.StatusCode, r.HTTPResponse.Status)
 	}
-	Debugf("retryable: %v -- %v, will retry after %v", err, method, duration)
+	Infof("retryable: %v -- %v, will retry after %v", err, method, duration)
 
 	return duration
 }


### PR DESCRIPTION
Testing Done:

- Verified that the new docker image can be built with aws-sdk v1.25.0
- Verified that rolling upgrade actually completed.