### PR TITLE
wait for node unjoined

### DIFF
--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -235,10 +235,9 @@ func (r *RollingUpgradeReconciler) WaitForTermination(nodeName string, nodeInter
 		started    = time.Now()
 	)
 	for {
-
-		if time.Since(started) > (time.Second * time.Duration(TerminationTimeoutSeconds)) {
+		if time.Since(started) >= (time.Second * time.Duration(TerminationTimeoutSeconds)) {
 			log.Println("WaitForTermination timed out while waiting for node to unjoin")
-			break
+			return false, nil
 		}
 
 		nodeList, err := nodeInterface.List(metav1.ListOptions{})

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -1956,12 +1956,15 @@ func TestWaitForTermination(t *testing.T) {
 	}
 	nodeInterface.Create(mockNode)
 
-	err = rcRollingUpgrade.WaitForTermination(mockNodeName, nodeInterface)
-	g.Expect(err).To(gomega.HaveOccurred())
+	unjoined, err := rcRollingUpgrade.WaitForTermination(mockNodeName, nodeInterface)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(unjoined).To(gomega.BeFalse())
 
 	nodeInterface.Delete(mockNodeName, &metav1.DeleteOptions{})
-	err = rcRollingUpgrade.WaitForTermination(mockNodeName, nodeInterface)
+
+	unjoined, err = rcRollingUpgrade.WaitForTermination(mockNodeName, nodeInterface)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(unjoined).To(gomega.BeTrue())
 }
 
 func TestRunRestackWithNodesLessThanMaxUnavailable(t *testing.T) {

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -1926,6 +1927,41 @@ func TestRunRestackNoNodeInAsg(t *testing.T) {
 	nodesProcessed, err := rcRollingUpgrade.runRestack(&ctx, ruObj, mockAutoscalingGroup, KubeCtlBinary)
 	g.Expect(nodesProcessed).To(gomega.Equal(0))
 	g.Expect(err).To(gomega.BeNil())
+}
+
+func TestWaitForTermination(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	TerminationTimeoutSeconds = 1
+	TerminationSleepIntervalSeconds = 1
+
+	mockNodeName := "node-123"
+	mockNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mockNodeName,
+		},
+	}
+	kuberenetesClient := fake.NewSimpleClientset()
+	nodeInterface := kuberenetesClient.CoreV1().Nodes()
+
+	mgr, err := manager.New(cfg, manager.Options{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	rcRollingUpgrade := &RollingUpgradeReconciler{
+		Client:          mgr.GetClient(),
+		generatedClient: kubernetes.NewForConfigOrDie(mgr.GetConfig()),
+		admissionMap:    sync.Map{},
+		ruObjNameToASG:  sync.Map{},
+		ClusterState:    NewClusterState(),
+	}
+	nodeInterface.Create(mockNode)
+
+	err = rcRollingUpgrade.WaitForTermination(mockNodeName, nodeInterface)
+	g.Expect(err).To(gomega.HaveOccurred())
+
+	nodeInterface.Delete(mockNodeName, &metav1.DeleteOptions{})
+	err = rcRollingUpgrade.WaitForTermination(mockNodeName, nodeInterface)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
 func TestRunRestackWithNodesLessThanMaxUnavailable(t *testing.T) {


### PR DESCRIPTION
Fixes #33 

This PR waits for node object to be unjoined before proceeding with rolling upgrade.

There is a hard limit on how long to wait which is now capped at an hour, if timeout occurs, upgrade will disregard and proceed anyway - we can make this configurable in CR if desired.

Added some unit test for new method.

## Testing

- Unit tests passing
- Manual testing - TBD in progress