### PR TITLE
Use go 1.13 for building

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,5 @@
 # For more Go information and examples, see
-# https://docs.semaphoreci.com/article/86-language-golang
+# https://docs.semaphoreci.com/programming-languages/go/
 version: v1.0
 name: Upgrade Manager
 agent:
@@ -8,7 +8,7 @@ agent:
     # os_image: ubuntu1804
   containers:
     - name: main
-      image: semaphoreci/golang:1.12.9
+      image: semaphoreci/golang:1.13.6
 blocks:
   - name: Setup
     task:
@@ -23,21 +23,21 @@ blocks:
     task:
       prologue:
         commands:
-          - cache restore $SEMAPHORE_PROJECT_NAME-dep
+          - checkout
+          - cache restore $SEMAPHORE_PROJECT_NAME-dep-$(checksum .semaphore/setup.sh)
           - ls -l /packages
           - pushd /packages
-          - sudo tar -xvf go1.12.7.linux-amd64.tar.gz
+          - sudo tar -xf go1.13.6.linux-amd64.tar.gz
           - sudo cp go/bin/go /usr/local/bin
           - sudo rm -rf /usr/local/go
           - sudo mv go /usr/local
           - export os=$(go env GOOS)
           - export arch=$(go env GOARCH)
-          - tar -xzvf kubebuilder_master_${os}_${arch}.tar.gz
+          - tar -xzf kubebuilder_master_${os}_${arch}.tar.gz
           - sudo mv kubebuilder_master_${os}_${arch} /usr/local/kubebuilder
           - ls /usr/local/kubebuilder
           - export PATH=$PATH:/usr/local/kubebuilder/bin
           - popd
-          - checkout
       jobs:
         - name: Docker Build
           commands:

--- a/.semaphore/setup.sh
+++ b/.semaphore/setup.sh
@@ -1,13 +1,11 @@
-cache restore $SEMAPHORE_PROJECT_NAME-dep
+cache restore $SEMAPHORE_PROJECT_NAME-dep-$(checksum .semaphore/setup.sh)
 # checks if the packages are already installed
-if [ ! -d '/packages' ]; then
+if [ ! -d '/packages' -o ! -f '/packages/go1.13.6.linux-amd64.tar.gz' ]; then
   sudo mkdir -p /packages
-  wget https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz
-  sudo mv go1.12.7.linux-amd64.tar.gz /packages
+  wget -P /packages/ https://dl.google.com/go/go1.13.6.linux-amd64.tar.gz
   export os=$(go env GOOS)
   export arch=$(go env GOARCH)
-  curl -sL https://go.kubebuilder.io/dl/latest/${os}/${arch} -o kubebuilder_master_${os}_${arch}.tar.gz
-  sudo mv kubebuilder_master_${os}_${arch}.tar.gz /packages
+  curl -sL https://go.kubebuilder.io/dl/latest/${os}/${arch} -o /packages/kubebuilder_master_${os}_${arch}.tar.gz
   ls -l /packages
-  cache store $SEMAPHORE_PROJECT_NAME-dep /packages
+  cache store $SEMAPHORE_PROJECT_NAME-dep-$(checksum .semaphore/setup.sh) /packages
 fi


### PR DESCRIPTION
Noticed, that semaphore uses old version of golang.
Bumped to latest 1.13.