### PR TITLE
Check version by value, not by pointers

### DIFF
--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -979,6 +979,8 @@ func (r *RollingUpgradeReconciler) UpdateInstance(ctx *context.Context,
 		r.Update(*ctx, ruObj)
 		ch <- nil
 		return
+	} else {
+		log.Printf("Will replace instance: %s", targetInstanceID)
 	}
 
 	nodeName := r.getNodeName(i, r.NodeList, ruObj)
@@ -1050,7 +1052,7 @@ func requiresRefresh(ec2Instance *autoscaling.Instance, definition *launchDefini
 		if aws.StringValue(instanceLaunchTemplate.LaunchTemplateName) != aws.StringValue(targetLaunchTemplate.LaunchTemplateName) {
 			return true
 		}
-		if aws.String(*instanceLaunchTemplate.Version) != aws.String(*targetLaunchTemplate.Version) {
+		if aws.StringValue(instanceLaunchTemplate.Version) != aws.StringValue(targetLaunchTemplate.Version) {
 			return true
 		}
 	}

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -2236,3 +2236,26 @@ func TestRequiresRefreshHandlesLaunchTemplateIDUpdate(t *testing.T) {
 	result := requiresRefresh(&mockInstance, &definition)
 	g.Expect(result).To(gomega.Equal(true))
 }
+
+func TestRequiresRefreshNotUpdateIfNoVersionChange(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mockID := "some-id"
+	oldLaunchTemplate := &autoscaling.LaunchTemplateSpecification{
+		LaunchTemplateId: aws.String("launch-template-id-v1"),
+		Version:          aws.String("1"),
+	}
+	az := "az-1"
+	mockInstance := autoscaling.Instance{InstanceId: &mockID, LaunchTemplate: oldLaunchTemplate, AvailabilityZone: &az}
+
+	newLaunchTemplate := &autoscaling.LaunchTemplateSpecification{
+		LaunchTemplateId: aws.String("launch-template-id-v1"),
+		Version:          aws.String("1"),
+	}
+	definition := launchDefinition{
+		launchTemplate: newLaunchTemplate,
+	}
+
+	result := requiresRefresh(&mockInstance, &definition)
+	g.Expect(result).To(gomega.Equal(false))
+}


### PR DESCRIPTION
Found out that check if version changed was incorrect and caused rollouts when it should not.