### PR TITLE
Use go 1.13.8 in Dockerfile

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,7 +8,7 @@ agent:
     # os_image: ubuntu1804
   containers:
     - name: main
-      image: semaphoreci/golang:1.13.6
+      image: semaphoreci/golang:1.13.8
 blocks:
   - name: Setup
     task:
@@ -27,7 +27,7 @@ blocks:
           - cache restore $SEMAPHORE_PROJECT_NAME-dep-$(checksum .semaphore/setup.sh)
           - ls -l /packages
           - pushd /packages
-          - sudo tar -xf go1.13.6.linux-amd64.tar.gz
+          - sudo tar -xf go1.13.8.linux-amd64.tar.gz
           - sudo cp go/bin/go /usr/local/bin
           - sudo rm -rf /usr/local/go
           - sudo mv go /usr/local

--- a/.semaphore/setup.sh
+++ b/.semaphore/setup.sh
@@ -1,8 +1,8 @@
 cache restore $SEMAPHORE_PROJECT_NAME-dep-$(checksum .semaphore/setup.sh)
 # checks if the packages are already installed
-if [ ! -d '/packages' -o ! -f '/packages/go1.13.6.linux-amd64.tar.gz' ]; then
+if [ ! -d '/packages' -o ! -f '/packages/go1.13.8.linux-amd64.tar.gz' ]; then
   sudo mkdir -p /packages
-  wget -P /packages/ https://dl.google.com/go/go1.13.6.linux-amd64.tar.gz
+  wget -P /packages/ https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz
   export os=$(go env GOOS)
   export arch=$(go env GOARCH)
   curl -sL https://go.kubebuilder.io/dl/latest/${os}/${arch} -o /packages/kubebuilder_master_${os}_${arch}.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.12.5 as builder
+FROM golang:1.13.8 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
Use go 1.13 in Dockerfile to build the image.

Performed testing:
1. Built new docker image with new version.
2. Performed rollout upgrade using new version of upgrade manager.
3. No errors / crashes with new image.