### PR TITLE
Set version to v0.7 and update CHANGELOG

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [v0.7] - 2020-02-28
 
-* Eager mode: Fix parallel RU bug (#57)
+* Fix parallel RU bug (#57)
+* Upgrade golang version to 1.13.8 (#56)
+* Check version by value rather than ptr (#55)
+* Add missing RBAC for node list/get (#53)
 
 ## [v0.6] - 2020-01-27
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v0.6.1] - 2020-02-28
+
+* Eager mode: Fix parallel RU bug (#57)
 
 ## [v0.6] - 2020-01-27
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [v0.6.1] - 2020-02-28
+## [v0.7] - 2020-02-28
 
 * Eager mode: Fix parallel RU bug (#57)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.6.1
+VERSION=0.7
 # Image URL to use all building/pushing image targets
 IMG ?= keikoproj/rolling-upgrade-controller:${VERSION}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.7-dev
+VERSION=0.6.1
 # Image URL to use all building/pushing image targets
 IMG ?= keikoproj/rolling-upgrade-controller:${VERSION}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: keikoproj/rolling-upgrade-controller:0.6.1
+      - image: keikoproj/rolling-upgrade-controller:0.7
         name: manager

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: keikoproj/rolling-upgrade-controller:0.7-dev
+      - image: keikoproj/rolling-upgrade-controller:0.6.1
         name: manager

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -112,7 +112,6 @@ type RollingUpgradeReconciler struct {
 	EC2Client       ec2iface.EC2API
 	ASGClient       autoscalingiface.AutoScalingAPI
 	generatedClient *kubernetes.Clientset
-	Asg             *autoscaling.Group
 	NodeList        *corev1.NodeList
 	admissionMap    sync.Map
 	ruObjNameToASG  sync.Map


### PR DESCRIPTION
I did mark the latest commit with v0.7 tag in my forked repo, but I'm not sure if the tag will be communicated back to keikoproj version of repo as a part of this PR.

If not, I may need to ask someone with core repo permissions to carryout the tagging process.