### PR TITLE
Refactor & Improvements

### DIFF
--- a/api/v1alpha1/rollingupgrade_types.go
+++ b/api/v1alpha1/rollingupgrade_types.go
@@ -60,6 +60,7 @@ type RollingUpgradeStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=rollingupgrades,scope=Namespaced,shortName=ru
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.currentStatus",description="current status of the rollingupgarde"
 // +kubebuilder:printcolumn:name="TotalNodes",type="string",JSONPath=".status.totalNodes",description="total nodes involved in the rollingupgarde"

--- a/config/crd/bases/upgrademgr.keikoproj.io_rollingupgrades.yaml
+++ b/config/crd/bases/upgrademgr.keikoproj.io_rollingupgrades.yaml
@@ -30,7 +30,8 @@ spec:
     - ru
     singular: rollingupgrade
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: RollingUpgrade is the Schema for the rollingupgrades API

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -369,20 +369,7 @@ func (r *RollingUpgradeReconciler) SetStandby(ruObj *upgrademgrv1alpha1.RollingU
 
 	_, err = r.ASGClient.EnterStandby(input)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			if strings.Contains(aerr.Message(), "not found") {
-				log.Printf("%v: Instance %s not found. Moving on\n", ruObj.Name, instanceID)
-				return nil
-			}
-			switch aerr.Code() {
-			case autoscaling.ErrCodeResourceContentionFault:
-				log.Warnf("%v: instance %v failed to enter standby due to resource contention: %v", ruObj.Name, instanceID, aerr.Error())
-				return nil
-			default:
-				log.Errorf("%v: instance %v failed to enter standby due to unexpected reason: %v", ruObj.Name, instanceID, aerr.Error())
-				return err
-			}
-		}
+		log.Warnf("%v: instance %v failed to enter standby: %v", ruObj.Name, instanceID, err)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR makes the following changes:

- Use `StatusWriter` instead of updating the entire spec, this will prevent triggering additional reconciles
  - This requires adding the subresource status and CRD change
- Have a single full CR update at the end of reconcile (i.e. `r.Update()`)
- Log error when CR updating fails instead of silently proceeding
- Basic refactor and code cleanup
- Never error out a CR if you fail to `EnterStandby`, fixes #62 


## Testing
- [x] Full rolling upgrade of multiple instance groups in parallel
- [x] Rolling upgrade (eager) with random scale-down in the middle
