### PR TITLE
Fix shadowing of error variable

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,8 +33,8 @@ blocks:
           - sudo mv go /usr/local
           - export os=$(go env GOOS)
           - export arch=$(go env GOARCH)
-          - tar -xzf kubebuilder_master_${os}_${arch}.tar.gz
-          - sudo mv kubebuilder_master_${os}_${arch} /usr/local/kubebuilder
+          - tar -xzf kubebuilder_2.3.0_${os}_${arch}.tar.gz
+          - sudo mv kubebuilder_2.3.0_${os}_${arch} /usr/local/kubebuilder
           - ls /usr/local/kubebuilder
           - export PATH=$PATH:/usr/local/kubebuilder/bin
           - popd

--- a/.semaphore/setup.sh
+++ b/.semaphore/setup.sh
@@ -1,11 +1,16 @@
 cache restore $SEMAPHORE_PROJECT_NAME-dep-$(checksum .semaphore/setup.sh)
 # checks if the packages are already installed
-if [ ! -d '/packages' -o ! -f '/packages/go1.13.8.linux-amd64.tar.gz' ]; then
+GO_VERSION=1.13.8
+KUBE_BUILDER_VERSION=2.3.0
+GO_PACKAGE="/packages/go${GO_VERSION}.linux-amd64.tar.gz"
+export os=$(go env GOOS)
+export arch=$(go env GOARCH)
+KUBE_BUILDER_PACKAGE="/packages/kubebuilder_${KUBE_BUILDER_VERSION}_${os}_${arch}.tar.gz"
+
+if [ ! -d '/packages' -o ! -f "${GO_PACKAGE}" -o ! -f "${KUBE_BUILDER_PACKAGE}" ]; then
   sudo mkdir -p /packages
-  wget -P /packages/ https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz
-  export os=$(go env GOOS)
-  export arch=$(go env GOARCH)
-  curl -sL https://go.kubebuilder.io/dl/latest/${os}/${arch} -o /packages/kubebuilder_master_${os}_${arch}.tar.gz
+  curl -sL "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" -o "${GO_PACKAGE}"
+  curl -sL "https://go.kubebuilder.io/dl/${KUBE_BUILDER_VERSION}/${os}/${arch}" -o "${KUBE_BUILDER_PACKAGE}"
   ls -l /packages
   cache store $SEMAPHORE_PROJECT_NAME-dep-$(checksum .semaphore/setup.sh) /packages
 fi

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: manager
 
 # Run tests
 test: generate fmt vet manifests
-	go test ./api/... ./controllers/... -coverprofile cover.out
+	go test ./api/... ./controllers/... -coverprofile cover.out -v
 	go tool cover -html=./cover.out -o cover.html
 
 # Build manager binary

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -251,9 +251,9 @@ func (r *RollingUpgradeReconciler) CallKubectlDrain(ctx context.Context, nodeNam
 }
 
 func (r *RollingUpgradeReconciler) WaitForDesiredInstances(ruObj *upgrademgrv1alpha1.RollingUpgrade) error {
-
 	var err error
-	for ieb, err := iebackoff.NewIEBackoff(WaiterMaxDelay, WaiterMinDelay, 0.5, WaiterMaxAttempts); err == nil; err = ieb.Next() {
+	var ieb *iebackoff.IEBackoff
+	for ieb, err = iebackoff.NewIEBackoff(WaiterMaxDelay, WaiterMinDelay, 0.5, WaiterMaxAttempts); err == nil; err = ieb.Next() {
 		err = r.populateAsg(ruObj)
 		if err != nil {
 			return err
@@ -276,9 +276,9 @@ func (r *RollingUpgradeReconciler) WaitForDesiredInstances(ruObj *upgrademgrv1al
 }
 
 func (r *RollingUpgradeReconciler) WaitForDesiredNodes(ruObj *upgrademgrv1alpha1.RollingUpgrade) error {
-
 	var err error
-	for ieb, err := iebackoff.NewIEBackoff(WaiterMaxDelay, WaiterMinDelay, 0.5, WaiterMaxAttempts); err == nil; err = ieb.Next() {
+	var ieb *iebackoff.IEBackoff
+	for ieb, err = iebackoff.NewIEBackoff(WaiterMaxDelay, WaiterMinDelay, 0.5, WaiterMaxAttempts); err == nil; err = ieb.Next() {
 		r.populateNodeList(ruObj, r.generatedClient.CoreV1().Nodes())
 
 		asg, err := r.GetAutoScalingGroup(ruObj.Name)
@@ -777,7 +777,7 @@ func (r *RollingUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *RollingUpgradeReconciler) setStateTag(ruObj *upgrademgrv1alpha1.RollingUpgrade, instanceID string, state string) error {
-	log.Printf("%v: setting instance %v state to %v", ruObj.Name, instanceID, state)
+	log.Printf("%v: setting instance %q state to %q", ruObj.Name, instanceID, state)
 	err := tagEC2instance(instanceID, EC2StateTagKey, state, r.EC2Client)
 	if err != nil {
 		return err

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/client-go/kubernetes/scheme"
+
 	"github.com/keikoproj/upgrade-manager/pkg/log"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -78,7 +80,7 @@ func TestErrorStatusMarkJanitor(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	instance := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -781,7 +783,7 @@ func TestFinishExecutionCompleted(t *testing.T) {
 	startTime := time.Now()
 	ruObj.Status.StartTime = startTime.Format(time.RFC3339)
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -809,7 +811,7 @@ func TestFinishExecutionError(t *testing.T) {
 
 	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 	rcRollingUpgrade := &RollingUpgradeReconciler{
@@ -853,7 +855,7 @@ func TestRunRestackSuccessOneNode(t *testing.T) {
 		Spec:       upgrademgrv1alpha1.RollingUpgradeSpec{AsgName: someAsg},
 	}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -901,7 +903,7 @@ func TestRunRestackSuccessMultipleNodes(t *testing.T) {
 	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
 		Spec: upgrademgrv1alpha1.RollingUpgradeSpec{AsgName: someAsg}}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -947,7 +949,7 @@ func TestRunRestackSameLaunchConfig(t *testing.T) {
 	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
 		Spec: upgrademgrv1alpha1.RollingUpgradeSpec{AsgName: someAsg}}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -985,7 +987,7 @@ func TestRunRestackRollingUpgradeNotInMap(t *testing.T) {
 	int, err := rcRollingUpgrade.runRestack(&ctx, ruObj, KubeCtlBinary)
 	g.Expect(int).To(gomega.Equal(0))
 	g.Expect(err).To(gomega.Not(gomega.BeNil()))
-	g.Expect(err.Error()).To(gomega.HavePrefix("Failed to find rollingUpgrade name in map."))
+	g.Expect(err.Error()).To(gomega.HavePrefix("Unable to load ASG with name: foo"))
 }
 
 func TestRunRestackRollingUpgradeNodeNameNotFound(t *testing.T) {
@@ -1004,7 +1006,7 @@ func TestRunRestackRollingUpgradeNodeNameNotFound(t *testing.T) {
 	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
 		Spec: upgrademgrv1alpha1.RollingUpgradeSpec{AsgName: someAsg}}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -1045,7 +1047,7 @@ func TestRunRestackNoNodeName(t *testing.T) {
 	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
 		Spec: upgrademgrv1alpha1.RollingUpgradeSpec{AsgName: someAsg}}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -1101,10 +1103,13 @@ func TestRunRestackDrainNodeFail(t *testing.T) {
 		Spec: upgrademgrv1alpha1.RollingUpgradeSpec{
 			AsgName:  someAsg,
 			PreDrain: somePreDrain,
+			Strategy: upgrademgrv1alpha1.UpdateStrategy{
+				Mode: "eager",
+			},
 		},
 	}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -1131,6 +1136,7 @@ func TestRunRestackDrainNodeFail(t *testing.T) {
 
 	// This execution gets past the different launch config check, but fails to drain the node because of a predrain failing script
 	nodesProcessed, err := rcRollingUpgrade.runRestack(&ctx, ruObj, KubeCtlBinary)
+
 	g.Expect(nodesProcessed).To(gomega.Equal(1))
 	g.Expect(err.Error()).To(gomega.HavePrefix("Error updating instances, ErrorCount: 1, Errors: ["))
 }
@@ -1148,14 +1154,21 @@ func TestRunRestackTerminateNodeFail(t *testing.T) {
 		LaunchConfigurationName: &someLaunchConfig,
 		Instances:               []*autoscaling.Instance{&mockInstance}}
 
-	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
-		Spec: upgrademgrv1alpha1.RollingUpgradeSpec{AsgName: someAsg}}
+	ruObj := &upgrademgrv1alpha1.RollingUpgrade{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+		Spec: upgrademgrv1alpha1.RollingUpgradeSpec{
+			AsgName: someAsg,
+			Strategy: upgrademgrv1alpha1.UpdateStrategy{
+				Mode: "eager",
+			},
+		},
+	}
 	// Error flag set, should return error
 	mockAutoscalingGroup := MockAutoscalingGroup{errorFlag: true, awsErr: awserr.New("some-other-aws-error",
 		"some message",
 		errors.New("some error"))}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -1226,7 +1239,7 @@ func TestUniformAcrossAzUpdateSuccessMultipleNodes(t *testing.T) {
 		},
 	}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -1294,7 +1307,7 @@ func TestUpdateInstances(t *testing.T) {
 	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
 		Spec: upgrademgrv1alpha1.RollingUpgradeSpec{AsgName: someAsg}}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -1349,7 +1362,7 @@ func TestUpdateInstancesError(t *testing.T) {
 			"some message",
 			nil)}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -1411,7 +1424,7 @@ func TestUpdateInstancesPartialError(t *testing.T) {
 		errorInstanceId: mockID2,
 	}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -1451,7 +1464,7 @@ func TestUpdateInstancesPartialError(t *testing.T) {
 func TestUpdateInstancesWithZeroInstances(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -2064,7 +2077,7 @@ func TestRunRestackNoNodeInAsg(t *testing.T) {
 		},
 	}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
@@ -2103,7 +2116,7 @@ func TestWaitForTermination(t *testing.T) {
 	kuberenetesClient := fake.NewSimpleClientset()
 	nodeInterface := kuberenetesClient.CoreV1().Nodes()
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	rcRollingUpgrade := &RollingUpgradeReconciler{
@@ -2132,6 +2145,14 @@ func TestWaitForTermination(t *testing.T) {
 	g.Expect(unjoined).To(gomega.BeTrue())
 }
 
+func buildManager() (manager.Manager, error) {
+	err := upgrademgrv1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		return nil, err
+	}
+	return manager.New(cfg, manager.Options{MetricsBindAddress: "0"})
+}
+
 func TestRunRestackWithNodesLessThanMaxUnavailable(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
@@ -2154,7 +2175,7 @@ func TestRunRestackWithNodesLessThanMaxUnavailable(t *testing.T) {
 		},
 	}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := buildManager()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -55,7 +55,8 @@ var _ = BeforeSuite(func(done Done) {
 		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	k8s.io/client-go v0.17.0
 	k8s.io/utils v0.0.0-20191218082557-f07c713de883 // indirect
 	sigs.k8s.io/controller-runtime v0.4.0
-	sigs.k8s.io/controller-tools v0.2.4 // indirect
 )
 
 replace github.com/keikoproj/upgrade-manager/pkg/log => ./pkg/log

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,6 @@ github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/gobuffalo/flect v0.1.5 h1:xpKq9ap8MbYfhuPCF0dBH854Gp9CxZjr/IocxELFflo=
-github.com/gobuffalo/flect v0.1.5/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d h1:3PaI8p3seN09VjbTYC/QWlUZdZ1qS1zGjy7LH2Wt07I=
@@ -220,11 +218,7 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
-github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
-github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
-github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -411,7 +405,6 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -500,8 +493,6 @@ gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966 h1:B0J02caTR6tpSJozBJyiAzT6CtBzjclw4pgm9gg8Ys0=
-gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
@@ -550,8 +541,6 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9NPsg=
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
-sigs.k8s.io/controller-tools v0.2.4 h1:la1h46EzElvWefWLqfsXrnsO3lZjpkI0asTpX6h8PLA=
-sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=


### PR DESCRIPTION
Fixes #64.

**Before:**
```
upgrade-manager-6b6c6b6988-g58dh rolling-upgrade-controller time="2020-03-06T22:16:46Z" level=info msg="rollingupgrade-node-us-west-2a: new node has not yet joined the cluster"
upgrade-manager-6b6c6b6988-g58dh rolling-upgrade-controller time="2020-03-06T22:17:01Z" level=info msg="rollingupgrade-node-us-west-2a: new node has not yet joined the cluster"
upgrade-manager-6b6c6b6988-g58dh rolling-upgrade-controller time="2020-03-06T22:17:01Z" level=info msg="rollingupgrade-node-us-west-2a: Running script echo \"Pods at PreDrain:\"\nkubectl get pods --all-namespaces --field-selector spec.nodeName=${INSTANCE_NAME}\n"
upgrade-manager-6b6c6b6988-g58dh rolling-upgrade-controller time="2020-03-06T22:17:02Z" level=info msg="rollingupgrade-node-us-west-2a: Script finished with output: Pods at PreDrain:\nNAMESPACE     NAME                                      READY
```

**Before with extra logging:**
```
upgrade-manager-98555bcf8-thcfp rolling-upgrade-controller time="2020-03-06T23:04:35Z" level=info msg="rollingupgrade-node-us-west-2b: new node has not yet joined the cluster"
upgrade-manager-98555bcf8-thcfp rolling-upgrade-controller time="2020-03-06T23:04:35Z" level=info msg="Got error: <nil>"
upgrade-manager-98555bcf8-thcfp rolling-upgrade-controller time="2020-03-06T23:04:35Z" level=info msg="Got result error: <nil>"
upgrade-manager-98555bcf8-thcfp rolling-upgrade-controller time="2020-03-06T23:04:35Z" level=info msg="rollingupgrade-node-us-west-2b: Running script echo \"Pods at PreDrain:\"\nkubectl get pods --all-namespaces --field-selector spec.nodeName=${INSTANCE_NAME}\n"
```

**After:**

```
upgrade-manager-ff6c8475f-7tgpz rolling-upgrade-controller time="2020-03-06T23:26:14Z" level=info msg="rollingupgrade-node-us-west-2c: new node has not yet joined the cluster"
upgrade-manager-ff6c8475f-7tgpz rolling-upgrade-controller time="2020-03-06T23:26:14Z" level=info msg="Got error: No more retries left"
upgrade-manager-ff6c8475f-7tgpz rolling-upgrade-controller time="2020-03-06T23:26:14Z" level=info msg="Got result error: rollingupgrade-node-us-west-2c: WaitForDesiredNodes timed out while waiting for nodes to join: No more retries left"
```