### PR TITLE
Use existing go version, simplify maintenance

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,14 +27,9 @@ blocks:
           - cache restore $SEMAPHORE_PROJECT_NAME-dep-$(checksum .semaphore/setup.sh)
           - ls -l /packages
           - pushd /packages
-          - sudo tar -xf go1.13.8.linux-amd64.tar.gz
-          - sudo cp go/bin/go /usr/local/bin
-          - sudo rm -rf /usr/local/go
-          - sudo mv go /usr/local
-          - export os=$(go env GOOS)
-          - export arch=$(go env GOARCH)
-          - tar -xzf kubebuilder_2.3.0_${os}_${arch}.tar.gz
-          - sudo mv kubebuilder_2.3.0_${os}_${arch} /usr/local/kubebuilder
+          - mkdir kubebuilder
+          - tar -xzf kubebuilder.tar.gz -C kubebuilder --strip-components=1
+          - sudo mv kubebuilder /usr/local/kubebuilder
           - ls /usr/local/kubebuilder
           - export PATH=$PATH:/usr/local/kubebuilder/bin
           - popd

--- a/.semaphore/setup.sh
+++ b/.semaphore/setup.sh
@@ -1,16 +1,14 @@
 cache restore $SEMAPHORE_PROJECT_NAME-dep-$(checksum .semaphore/setup.sh)
-# checks if the packages are already installed
-GO_VERSION=1.13.8
 KUBE_BUILDER_VERSION=2.3.0
-GO_PACKAGE="/packages/go${GO_VERSION}.linux-amd64.tar.gz"
 export os=$(go env GOOS)
 export arch=$(go env GOARCH)
-KUBE_BUILDER_PACKAGE="/packages/kubebuilder_${KUBE_BUILDER_VERSION}_${os}_${arch}.tar.gz"
-
-if [ ! -d '/packages' -o ! -f "${GO_PACKAGE}" -o ! -f "${KUBE_BUILDER_PACKAGE}" ]; then
+KUBE_BUILDER_PACKAGE="/packages/kubebuilder.tar.gz"
+KUBE_BUILDER_MARKER="/packages/kubebuilder_${KUBE_BUILDER_VERSION}.marker"
+# checks if the packages are already installed
+if [ ! -d '/packages' -o ! -f "${KUBE_BUILDER_MARKER}" ]; then
   sudo mkdir -p /packages
-  curl -sL "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" -o "${GO_PACKAGE}"
   curl -sL "https://go.kubebuilder.io/dl/${KUBE_BUILDER_VERSION}/${os}/${arch}" -o "${KUBE_BUILDER_PACKAGE}"
+  touch "${KUBE_BUILDER_MARKER}"
   ls -l /packages
   cache store $SEMAPHORE_PROJECT_NAME-dep-$(checksum .semaphore/setup.sh) /packages
 fi


### PR DESCRIPTION
* Use go version from docker image provided by semaphore
* Simplify script to improve maintainability - to upgrade kubebuilder only bump version in `setup.sh` is required.