### PR TITLE
Add SDK caching & Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ RollingUpgrade provides a Kubernetes native mechanism for doing rolling-updates 
 
 - The RollingUpgrade Kubernetes custom resource has the following options in the spec:
   - `asgName`: Name of the autoscaling group to perform the rolling-update.
-  - `region`: Name of the AWS region in which the ASG exists.
   - `preDrain.script`: The script to run before draining a node.
   - `postDrain.script`: The script to run after draining a node. This allows for performing actions such as quiescing network traffic, adding labels, etc.
   - `postDrain.waitSeconds`: The seconds to wait after a node is drained.

--- a/api/v1alpha1/rollingupgrade_types.go
+++ b/api/v1alpha1/rollingupgrade_types.go
@@ -41,7 +41,6 @@ type PostTerminateSpec struct {
 type RollingUpgradeSpec struct {
 	PostDrainDelaySeconds int               `json:"postDrainDelaySeconds,omitempty"`
 	NodeIntervalSeconds   int               `json:"nodeIntervalSeconds,omitempty"`
-	Region                string            `json:"region,omitempty"`
 	AsgName               string            `json:"asgName,omitempty"`
 	PreDrain              PreDrainSpec      `json:"preDrain,omitempty"`
 	PostDrain             PostDrainSpec     `json:"postDrain,omitempty"`

--- a/config/crd/bases/upgrademgr.keikoproj.io_rollingupgrades.yaml
+++ b/config/crd/bases/upgrademgr.keikoproj.io_rollingupgrades.yaml
@@ -83,8 +83,6 @@ spec:
                 script:
                   type: string
               type: object
-            region:
-              type: string
             strategy:
               description: UpdateStrategy holds the information needed to perform
                 update based on different update strategies

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -427,12 +427,6 @@ func (r *RollingUpgradeReconciler) TerminateNode(ruObj *upgrademgrv1alpha1.Rolli
 	return nil
 }
 
-func (r *RollingUpgradeReconciler) setDefaults(ruObj *upgrademgrv1alpha1.RollingUpgrade) {
-	if ruObj.Spec.Region == "" {
-		ruObj.Spec.Region = "us-west-2"
-	}
-}
-
 func (r *RollingUpgradeReconciler) getNodeName(i *autoscaling.Instance, nodeList *corev1.NodeList, ruObj *upgrademgrv1alpha1.RollingUpgrade) string {
 	node := r.getNodeFromAsg(i, nodeList, ruObj)
 	if node == nil {
@@ -645,8 +639,6 @@ func (r *RollingUpgradeReconciler) Process(ctx *context.Context,
 		logr.Info("Deleted object from admission map")
 		return reconcile.Result{}, nil
 	}
-
-	r.setDefaults(ruObj)
 
 	err := r.populateAsg(ruObj)
 	if err != nil {

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -678,6 +678,15 @@ func (r *RollingUpgradeReconciler) Process(ctx *context.Context,
 	}
 	cache.AddCaching(sess, cacheCfg)
 	cacheCfg.SetCacheTTL("autoscaling", "DescribeAutoScalingGroups", DescribeAutoScalingGroupsTTL)
+	sess.Handlers.Complete.PushFront(func(r *request.Request) {
+		ctx := r.HTTPRequest.Context()
+		log.Debugf("cache hit => %v, service => %s.%s",
+			cache.IsCacheHit(ctx),
+			r.ClientInfo.ServiceName,
+			r.Operation.Name,
+		)
+	})
+
 	r.ASGClient = autoscaling.New(sess)
 	r.EC2Client = ec2.New(sess)
 

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -451,8 +451,6 @@ func (r *RollingUpgradeReconciler) getNodeFromAsg(i *autoscaling.Instance, nodeL
 }
 
 func (r *RollingUpgradeReconciler) populateAsg(ruObj *upgrademgrv1alpha1.RollingUpgrade) error {
-	// Initialize a session in the given region that the SDK will use to load
-	// credentials.
 	input := &autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []*string{
 			aws.String(ruObj.Spec.AsgName),

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -640,6 +640,7 @@ func (r *RollingUpgradeReconciler) Process(ctx *context.Context,
 		return reconcile.Result{}, nil
 	}
 
+	r.CacheConfig.FlushCache("autoscaling")
 	err := r.populateAsg(ruObj)
 	if err != nil {
 		return r.finishExecution(StatusError, 0, ctx, ruObj)
@@ -960,7 +961,6 @@ func (r *RollingUpgradeReconciler) UpdateInstance(ctx *context.Context,
 	KubeCtlCall string,
 	ch chan error) {
 
-	r.CacheConfig.FlushCache("autoscaling")
 	// If the running node has the same launchconfig as the asg,
 	// there is no need to refresh it.
 	targetInstanceID := aws.StringValue(i.InstanceId)

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/go-logr/logr"
+	"github.com/keikoproj/aws-sdk-go-cache/cache"
 	iebackoff "github.com/keikoproj/inverse-exp-backoff"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -103,6 +104,7 @@ type RollingUpgradeReconciler struct {
 	ruObjNameToASG  sync.Map
 	ClusterState    ClusterState
 	maxParallel     int
+	CacheConfig     *cache.Config
 }
 
 func (r *RollingUpgradeReconciler) SetMaxParallel(max int) {
@@ -958,6 +960,7 @@ func (r *RollingUpgradeReconciler) UpdateInstance(ctx *context.Context,
 	KubeCtlCall string,
 	ch chan error) {
 
+	r.CacheConfig.FlushCache("autoscaling")
 	// If the running node has the same launchconfig as the asg,
 	// there is no need to refresh it.
 	targetInstanceID := aws.StringValue(i.InstanceId)

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -11,6 +11,7 @@ import (
 
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/keikoproj/aws-sdk-go-cache/cache"
 	"github.com/keikoproj/upgrade-manager/pkg/log"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -866,6 +867,7 @@ func TestRunRestackSuccessOneNode(t *testing.T) {
 		ruObjNameToASG:  sync.Map{},
 		NodeList:        &nodeList,
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
@@ -915,6 +917,7 @@ func TestRunRestackSuccessMultipleNodes(t *testing.T) {
 		ruObjNameToASG:  sync.Map{},
 		NodeList:        &nodeList,
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
@@ -952,6 +955,7 @@ func TestRunRestackSameLaunchConfig(t *testing.T) {
 		admissionMap:    sync.Map{},
 		ruObjNameToASG:  sync.Map{},
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
@@ -1011,6 +1015,7 @@ func TestRunRestackRollingUpgradeNodeNameNotFound(t *testing.T) {
 		ruObjNameToASG:  sync.Map{},
 		NodeList:        &emptyNodeList,
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
@@ -1057,6 +1062,7 @@ func TestRunRestackNoNodeName(t *testing.T) {
 		ruObjNameToASG:  sync.Map{},
 		NodeList:        &nodeList,
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
@@ -1120,6 +1126,7 @@ func TestRunRestackDrainNodeFail(t *testing.T) {
 		ruObjNameToASG:  sync.Map{},
 		NodeList:        &nodeList,
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
@@ -1179,6 +1186,7 @@ func TestRunRestackTerminateNodeFail(t *testing.T) {
 		ruObjNameToASG:  sync.Map{},
 		NodeList:        &nodeList,
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
@@ -1270,6 +1278,7 @@ func TestUniformAcrossAzUpdateSuccessMultipleNodes(t *testing.T) {
 		ruObjNameToASG:  sync.Map{},
 		NodeList:        &nodeList,
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
@@ -1326,6 +1335,7 @@ func TestUpdateInstances(t *testing.T) {
 		ruObjNameToASG:  sync.Map{},
 		NodeList:        &nodeList,
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
@@ -1389,6 +1399,7 @@ func TestUpdateInstancesError(t *testing.T) {
 		ruObjNameToASG:  sync.Map{},
 		NodeList:        &nodeList,
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
@@ -1459,6 +1470,7 @@ func TestUpdateInstancesPartialError(t *testing.T) {
 		ruObjNameToASG:  sync.Map{},
 		NodeList:        &nodeList,
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
@@ -1488,6 +1500,7 @@ func TestUpdateInstancesWithZeroInstances(t *testing.T) {
 		admissionMap:    sync.Map{},
 		ruObjNameToASG:  sync.Map{},
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 
 	ctx := context.TODO()
@@ -2104,6 +2117,7 @@ func TestRunRestackNoNodeInAsg(t *testing.T) {
 		admissionMap:    sync.Map{},
 		NodeList:        &nodeList,
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
@@ -2203,6 +2217,7 @@ func TestRunRestackWithNodesLessThanMaxUnavailable(t *testing.T) {
 		admissionMap:    sync.Map{},
 		ruObjNameToASG:  sync.Map{},
 		ClusterState:    NewClusterState(),
+		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 	rcRollingUpgrade.ClusterState.deleteEntryOfAsg(someAsg)

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -535,16 +535,6 @@ func TestLoadEnvironmentVariables(t *testing.T) {
 	g.Expect(os.Getenv(instanceNameKey)).To(gomega.Equal("instance-name-foo"))
 }
 
-func TestSetDefaults(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
-	rcRollingUpgrade := &RollingUpgradeReconciler{ClusterState: NewClusterState()}
-
-	g.Expect(ruObj.Spec.Region).To(gomega.Equal(""))
-	rcRollingUpgrade.setDefaults(ruObj)
-	g.Expect(ruObj.Spec.Region).To(gomega.Equal("us-west-2"))
-}
-
 func TestGetNodeNameFoundNode(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/docs/step-by-step-example.md
+++ b/docs/step-by-step-example.md
@@ -149,7 +149,6 @@ metadata:
   generateName: rollingupgrade-sample-
 spec:
     asgName: nodes.test-cluster-kops.cluster.k8s.local
-    region: us-west-2
     nodeIntervalSeconds: 300
     preDrain:
         script: |

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -4,7 +4,6 @@ metadata:
   generateName: rollingupgrade-sample-
 spec:
     asgName: my-asg
-    region: us-west-2
     nodeIntervalSeconds: 300
     postDrain:
         waitSeconds: 90

--- a/examples/pre_post_drain.yaml
+++ b/examples/pre_post_drain.yaml
@@ -4,7 +4,6 @@ metadata:
   generateName: rollingupgrade-sample-
 spec:
     asgName: my-asg-1
-    region: us-west-2
     nodeIntervalSeconds: 300
     preDrain:
         script: |

--- a/examples/random_update_strategy.yaml
+++ b/examples/random_update_strategy.yaml
@@ -4,7 +4,6 @@ metadata:
   generateName: rollingupgrade-sample-
 spec:
   asgName: my-asg-1
-  region: us-west-2
   nodeIntervalSeconds: 300
   preDrain:
     script: |

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,14 @@ require (
 	github.com/aws/aws-sdk-go v1.25.0
 	github.com/go-logr/logr v0.1.0
 	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a
 	github.com/keikoproj/inverse-exp-backoff v0.0.0-20191216014651-04523236b6ca
 	github.com/keikoproj/upgrade-manager/pkg/log v0.0.0
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.1
 	github.com/pkg/errors v0.8.1
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
-	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
+	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8 // indirect
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
 	gopkg.in/yaml.v2 v2.2.7

--- a/go.sum
+++ b/go.sum
@@ -21,7 +21,9 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -32,6 +34,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLM
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -78,7 +82,9 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
+github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/zapr v0.1.0 h1:h+WVe9j6HAA01niTJPA/kKH0i7e0rLZBCwauQFcRE54=
@@ -133,6 +139,7 @@ github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d h1:3PaI8p3seN09Vjb
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7 h1:u4bArs140e9+AfE52mFHOXVFnOSBJBRlzTHrOPLOIhE=
@@ -152,6 +159,8 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -196,6 +205,11 @@ github.com/json-iterator/go v1.1.8 h1:QiWkFLKq0T7mpzwOTu6BzNDbfTE8OLrYhVKYMLF46O
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/karlseguin/ccache v2.0.3+incompatible h1:j68C9tWOROiOLWTS/kCGg9IcJG+ACqn5+0+t8Oh83UU=
+github.com/karlseguin/ccache v2.0.3+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=
+github.com/karlseguin/expect v1.0.1/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
+github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a h1:T4PGY8X0NbpEPM3U7HxLX616PBgjWxvn2YQNYkdaEeU=
+github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a/go.mod h1:PqUW3kzHKLscAxysVG6mJz5wmk4JV9GSwX+k4qjqi1c=
 github.com/keikoproj/inverse-exp-backoff v0.0.0-20191216014651-04523236b6ca h1:uvqXVaFKbYgjOK+BHvtCMZIa+Mssmq7wuTJM5MPP5Sc=
 github.com/keikoproj/inverse-exp-backoff v0.0.0-20191216014651-04523236b6ca/go.mod h1:ziu/tMrrvs8n+AI+HCZBb6wZS609fcMl5ygR2RttEE4=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -272,15 +286,21 @@ github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
+github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275 h1:PnBWHBf+6L0jOqq0gIVUe6Yk0/QMZ640k6NvkxcBf+8=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.4.1 h1:K0MGApIoQvMw27RTdJkPbr3JZ7DNbtxQNyi5STVM6Kw=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.9.1 h1:KOMtN28tlbam3/7ZKEYKHhKoJZYYj3gMH4uc62x7X7U=
+github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a h1:9a8MnZMP0X2nLJdBg+pBmGgkJlSaKC2KaQmTCk1XDtE=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNGfs=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
+github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -318,6 +338,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0/go.mod h1:IXCdmsXIht47RaVFLEdVnh1t+pgYtTAhQGj73kz+2DM=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -383,6 +404,8 @@ golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa h1:F+8P+gmewFQYRk6JoLQLwjBCTu3mcIURZfNkVweuRKA=
+golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -478,6 +501,7 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/karlseguin/expect.v1 v1.0.1/go.mod h1:uB7QIJBcclvYbwlUDkSCsGjAOMis3fP280LyhuDEf2I=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=


### PR DESCRIPTION
Fixes #74 

Cache will expire once a minute, and be flushed whenever writes happen (Terminate/SetStandby/etc).

Added the required call to populateASG

## Refactor

The refactoring removes the region from spec and makes it a controller option controlled by a flag `--region`, this also deprecates the API option for `.spec.region` and removes all references to it.

SDK instantiation is moved to main.go in order to not mess up unit tests with caching

### Testing

- [x] Scale down does not fail rollup

#### while rollup was running on 1 node, killed other 2 in scaling group
```
time="2020-03-10T23:31:13Z" level=debug msg="cache hit => false, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:31:13Z" level=info msg="test-rollup: new instance has not yet joined the scaling group"
time="2020-03-10T23:32:44Z" level=debug msg="cache hit => false, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:32:44Z" level=info msg="test-rollup: desired capacity is met, 3 instances in service"
time="2020-03-10T23:32:44Z" level=debug msg="cache hit => true, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:32:44Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:34:14Z" level=debug msg="cache hit => false, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:34:14Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:34:59Z" level=debug msg="cache hit => true, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:34:59Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:35:21Z" level=debug msg="cache hit => false, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:35:21Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:35:36Z" level=debug msg="cache hit => true, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:35:36Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:35:51Z" level=debug msg="cache hit => true, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:35:51Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:36:06Z" level=debug msg="cache hit => true, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:36:06Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:36:21Z" level=debug msg="cache hit => false, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:36:21Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:36:36Z" level=debug msg="cache hit => true, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:36:36Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:36:51Z" level=debug msg="cache hit => true, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:36:51Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:37:06Z" level=debug msg="cache hit => true, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:37:06Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:37:22Z" level=debug msg="cache hit => false, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:37:22Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:37:37Z" level=debug msg="cache hit => true, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:37:37Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:37:52Z" level=debug msg="cache hit => true, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:37:52Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:38:07Z" level=debug msg="cache hit => true, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:38:07Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:38:22Z" level=debug msg="cache hit => false, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:38:22Z" level=info msg="test-rollup: new node has not yet joined the cluster"
time="2020-03-10T23:38:37Z" level=debug msg="cache hit => true, service => autoscaling.DescribeAutoScalingGroups"
time="2020-03-10T23:38:37Z" level=info msg="test-rollup: desired capacity is met, 3 nodes in service"
```


- [x] Many ASGs do not get throttled excessively 