### PR TITLE
Allow to ignore drain failures

### DIFF
--- a/api/v1alpha1/rollingupgrade_types.go
+++ b/api/v1alpha1/rollingupgrade_types.go
@@ -42,11 +42,14 @@ type PostTerminateSpec struct {
 type RollingUpgradeSpec struct {
 	PostDrainDelaySeconds int               `json:"postDrainDelaySeconds,omitempty"`
 	NodeIntervalSeconds   int               `json:"nodeIntervalSeconds,omitempty"`
+	// AsgName is AWS Autoscaling Group name to roll.
 	AsgName               string            `json:"asgName,omitempty"`
 	PreDrain              PreDrainSpec      `json:"preDrain,omitempty"`
 	PostDrain             PostDrainSpec     `json:"postDrain,omitempty"`
 	PostTerminate         PostTerminateSpec `json:"postTerminate,omitempty"`
 	Strategy              UpdateStrategy    `json:"strategy,omitempty"`
+	// IgnoreDrainFailures allows ignoring node drain failures and proceed with rolling upgrade.
+	IgnoreDrainFailures    bool              `json:"ignoreDrainFailures,omitempty"`
 }
 
 // RollingUpgradeStatus defines the observed state of RollingUpgrade

--- a/config/crd/bases/upgrademgr.keikoproj.io_rollingupgrades.yaml
+++ b/config/crd/bases/upgrademgr.keikoproj.io_rollingupgrades.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -53,6 +52,10 @@ spec:
           properties:
             asgName:
               type: string
+            ignoreDrainFailures:
+              description: IgnoreDrainFailures allows ignore node drain failures
+                and proceed with rolling upgrade.
+              type: boolean
             nodeIntervalSeconds:
               type: integer
             postDrain:

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -942,7 +942,7 @@ func (r *RollingUpgradeReconciler) DrainTerminate(
 
 	// Drain and wait for draining node.
 	err := r.DrainNode(ruObj, nodeName, KubeCtlCall, ruObj.Spec.Strategy.DrainTimeout)
-	if err != nil {
+	if err != nil && !ruObj.Spec.IgnoreDrainFailures {
 		ch <- err
 		return
 	}


### PR DESCRIPTION
Closes #81 

Allow to skip drain failures and proceed with termination. Useful on staging environments.
Disabled by default

Tested and confirmed working.