### PR TITLE
Add missing RBAC docs

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,6 +25,7 @@ blocks:
         commands:
           - checkout
           - cache restore $SEMAPHORE_PROJECT_NAME-dep-$(checksum .semaphore/setup.sh)
+          - source .semaphore/setup.sh
           - ls -l /packages
           - pushd /packages
           - mkdir kubebuilder

--- a/config/crd/bases/upgrademgr.keikoproj.io_rollingupgrades.yaml
+++ b/config/crd/bases/upgrademgr.keikoproj.io_rollingupgrades.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -51,9 +52,10 @@ spec:
           description: RollingUpgradeSpec defines the desired state of RollingUpgrade
           properties:
             asgName:
+              description: AsgName is AWS Autoscaling Group name to roll.
               type: string
             ignoreDrainFailures:
-              description: IgnoreDrainFailures allows ignore node drain failures
+              description: IgnoreDrainFailures allows ignoring node drain failures
                 and proceed with rolling upgrade.
               type: boolean
             nodeIntervalSeconds:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,6 +24,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -720,6 +720,7 @@ func MarkObjForCleanup(ruObj *upgrademgrv1alpha1.RollingUpgrade) {
 // +kubebuilder:rbac:groups=upgrademgr.keikoproj.io,resources=rollingupgrades/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=list
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create
 // +kubebuilder:rbac:groups=core,resources=pods/eviction,verbs=create
 // +kubebuilder:rbac:groups=extensions;apps,resources=daemonsets;replicasets;statefulsets,verbs=get
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get


### PR DESCRIPTION
Fixes #88 

This PR adds the missing RBAC via kubebuilder.
There is also a change that was not checked in for CRD (benign typo change)