### PR TITLE
Enable forceRefresh of nodes.

### DIFF
--- a/api/v1alpha1/rollingupgrade_types.go
+++ b/api/v1alpha1/rollingupgrade_types.go
@@ -40,16 +40,18 @@ type PostTerminateSpec struct {
 
 // RollingUpgradeSpec defines the desired state of RollingUpgrade
 type RollingUpgradeSpec struct {
-	PostDrainDelaySeconds int               `json:"postDrainDelaySeconds,omitempty"`
-	NodeIntervalSeconds   int               `json:"nodeIntervalSeconds,omitempty"`
+	PostDrainDelaySeconds int `json:"postDrainDelaySeconds,omitempty"`
+	NodeIntervalSeconds   int `json:"nodeIntervalSeconds,omitempty"`
 	// AsgName is AWS Autoscaling Group name to roll.
-	AsgName               string            `json:"asgName,omitempty"`
-	PreDrain              PreDrainSpec      `json:"preDrain,omitempty"`
-	PostDrain             PostDrainSpec     `json:"postDrain,omitempty"`
-	PostTerminate         PostTerminateSpec `json:"postTerminate,omitempty"`
-	Strategy              UpdateStrategy    `json:"strategy,omitempty"`
+	AsgName       string            `json:"asgName,omitempty"`
+	PreDrain      PreDrainSpec      `json:"preDrain,omitempty"`
+	PostDrain     PostDrainSpec     `json:"postDrain,omitempty"`
+	PostTerminate PostTerminateSpec `json:"postTerminate,omitempty"`
+	Strategy      UpdateStrategy    `json:"strategy,omitempty"`
 	// IgnoreDrainFailures allows ignoring node drain failures and proceed with rolling upgrade.
-	IgnoreDrainFailures    bool              `json:"ignoreDrainFailures,omitempty"`
+	IgnoreDrainFailures bool `json:"ignoreDrainFailures,omitempty"`
+	// ForceRefresh enables draining and terminating the node even if the launch config/template hasn't changed.
+	ForceRefresh bool `json:"forceRefresh,omitempty"`
 }
 
 // RollingUpgradeStatus defines the observed state of RollingUpgrade

--- a/config/crd/bases/upgrademgr.keikoproj.io_rollingupgrades.yaml
+++ b/config/crd/bases/upgrademgr.keikoproj.io_rollingupgrades.yaml
@@ -54,6 +54,10 @@ spec:
             asgName:
               description: AsgName is AWS Autoscaling Group name to roll.
               type: string
+            forceRefresh:
+              description: ForceRefresh enables draining and terminating the node
+                even if the launch config/template hasn't changed.
+              type: boolean
             ignoreDrainFailures:
               description: IgnoreDrainFailures allows ignoring node drain failures
                 and proceed with rolling upgrade.

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -990,6 +990,7 @@ func (r *RollingUpgradeReconciler) DrainTerminate(
 
 }
 
+// UpdateInstance runs the rolling upgrade on one instance from an autoscaling group
 func (r *RollingUpgradeReconciler) UpdateInstance(ctx *context.Context,
 	ruObj *upgrademgrv1alpha1.RollingUpgrade,
 	i *autoscaling.Instance,
@@ -1000,8 +1001,7 @@ func (r *RollingUpgradeReconciler) UpdateInstance(ctx *context.Context,
 	// If the running node has the same launchconfig as the asg,
 	// there is no need to refresh it.
 	targetInstanceID := aws.StringValue(i.InstanceId)
-	if !requiresRefresh(i, launchDefinition) {
-		r.info(ruObj, "Ignoring since it has the correct launch-config", "instanceID", targetInstanceID)
+	if !r.requiresRefresh(ruObj, i, launchDefinition) {
 		ruObj.Status.NodesProcessed = ruObj.Status.NodesProcessed + 1
 		if err := r.Status().Update(*ctx, ruObj); err != nil {
 			r.error(ruObj, err, "failed to update status")
@@ -1066,24 +1066,36 @@ func (r *RollingUpgradeReconciler) UpdateInstance(ctx *context.Context,
 	ch <- nil
 }
 
-func requiresRefresh(ec2Instance *autoscaling.Instance, definition *launchDefinition) bool {
+func (r *RollingUpgradeReconciler) requiresRefresh(ruObj *upgrademgrv1alpha1.RollingUpgrade, ec2Instance *autoscaling.Instance,
+	definition *launchDefinition) bool {
+
+	if ruObj.Spec.ForceRefresh {
+		r.info(ruObj, "rolling upgrade configured for forced refresh")
+		return true
+	}
 	if definition.launchConfigurationName != nil {
 		if *(definition.launchConfigurationName) != aws.StringValue(ec2Instance.LaunchConfigurationName) {
+			r.info(ruObj, "launch configuration name differs")
 			return true
 		}
 	} else if definition.launchTemplate != nil && ec2Instance.LaunchTemplate != nil {
 		instanceLaunchTemplate := ec2Instance.LaunchTemplate
 		targetLaunchTemplate := definition.launchTemplate
 		if aws.StringValue(instanceLaunchTemplate.LaunchTemplateId) != aws.StringValue(targetLaunchTemplate.LaunchTemplateId) {
+			r.info(ruObj, "launch template id differs")
 			return true
 		}
 		if aws.StringValue(instanceLaunchTemplate.LaunchTemplateName) != aws.StringValue(targetLaunchTemplate.LaunchTemplateName) {
+			r.info(ruObj, "launch template name differs")
 			return true
 		}
 		if aws.StringValue(instanceLaunchTemplate.Version) != aws.StringValue(targetLaunchTemplate.Version) {
+			r.info(ruObj, "launch template version differs")
 			return true
 		}
 	}
+
+	r.info(ruObj, "node refresh not required")
 	return false
 }
 

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -2289,6 +2289,9 @@ func TestRunRestackWithNodesLessThanMaxUnavailable(t *testing.T) {
 func TestRequiresRefreshHandlesLaunchConfiguration(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
+	r := &RollingUpgradeReconciler{Log: log2.NullLogger{}}
+	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+
 	mockID := "some-id"
 	someLaunchConfig := "some-launch-config-v1"
 	az := "az-1"
@@ -2299,7 +2302,7 @@ func TestRequiresRefreshHandlesLaunchConfiguration(t *testing.T) {
 		launchConfigurationName: &newLaunchConfig,
 	}
 
-	result := requiresRefresh(&mockInstance, &definition)
+	result := r.requiresRefresh(ruObj, &mockInstance, &definition)
 	g.Expect(result).To(gomega.Equal(true))
 }
 
@@ -2322,7 +2325,9 @@ func TestRequiresRefreshHandlesLaunchTemplateNameVersionUpdate(t *testing.T) {
 		launchTemplate: newLaunchTemplate,
 	}
 
-	result := requiresRefresh(&mockInstance, &definition)
+	r := &RollingUpgradeReconciler{Log: log2.NullLogger{}}
+	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+	result := r.requiresRefresh(ruObj, &mockInstance, &definition)
 	g.Expect(result).To(gomega.Equal(true))
 }
 
@@ -2344,8 +2349,9 @@ func TestRequiresRefreshHandlesLaunchTemplateIDVersionUpdate(t *testing.T) {
 	definition := launchDefinition{
 		launchTemplate: newLaunchTemplate,
 	}
-
-	result := requiresRefresh(&mockInstance, &definition)
+	r := &RollingUpgradeReconciler{Log: log2.NullLogger{}}
+	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+	result := r.requiresRefresh(ruObj, &mockInstance, &definition)
 	g.Expect(result).To(gomega.Equal(true))
 }
 
@@ -2367,8 +2373,9 @@ func TestRequiresRefreshHandlesLaunchTemplateNameUpdate(t *testing.T) {
 	definition := launchDefinition{
 		launchTemplate: newLaunchTemplate,
 	}
-
-	result := requiresRefresh(&mockInstance, &definition)
+	r := &RollingUpgradeReconciler{Log: log2.NullLogger{}}
+	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+	result := r.requiresRefresh(ruObj, &mockInstance, &definition)
 	g.Expect(result).To(gomega.Equal(true))
 }
 
@@ -2390,8 +2397,9 @@ func TestRequiresRefreshHandlesLaunchTemplateIDUpdate(t *testing.T) {
 	definition := launchDefinition{
 		launchTemplate: newLaunchTemplate,
 	}
-
-	result := requiresRefresh(&mockInstance, &definition)
+	r := &RollingUpgradeReconciler{Log: log2.NullLogger{}}
+	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+	result := r.requiresRefresh(ruObj, &mockInstance, &definition)
 	g.Expect(result).To(gomega.Equal(true))
 }
 
@@ -2413,8 +2421,68 @@ func TestRequiresRefreshNotUpdateIfNoVersionChange(t *testing.T) {
 	definition := launchDefinition{
 		launchTemplate: newLaunchTemplate,
 	}
+	r := &RollingUpgradeReconciler{Log: log2.NullLogger{}}
+	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+	result := r.requiresRefresh(ruObj, &mockInstance, &definition)
+	g.Expect(result).To(gomega.Equal(false))
+}
 
-	result := requiresRefresh(&mockInstance, &definition)
+func TestForceRefresh(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Even if launchtemplate is identical but forceRefresh is set, requiresRefresh should return true.
+	mockID := "some-id"
+	launchTemplate := &autoscaling.LaunchTemplateSpecification{
+		LaunchTemplateId: aws.String("launch-template-id-v1"),
+		Version:          aws.String("1"),
+	}
+	az := "az-1"
+	mockInstance := autoscaling.Instance{InstanceId: &mockID, LaunchTemplate: launchTemplate, AvailabilityZone: &az}
+
+	definition := launchDefinition{
+		launchTemplate: launchTemplate,
+	}
+	r := &RollingUpgradeReconciler{Log: log2.NullLogger{}}
+	ruObj := &upgrademgrv1alpha1.RollingUpgrade{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+		Spec: upgrademgrv1alpha1.RollingUpgradeSpec{
+			Strategy:     upgrademgrv1alpha1.UpdateStrategy{DrainTimeout: -1},
+			ForceRefresh: true,
+		},
+	}
+	result := r.requiresRefresh(ruObj, &mockInstance, &definition)
+	g.Expect(result).To(gomega.Equal(true))
+
+	// If launchTempaltes are different and forceRefresh is true, requiresRefresh should return true
+	newLaunchTemplate := &autoscaling.LaunchTemplateSpecification{
+		LaunchTemplateId: aws.String("launch-template-id-v1"),
+		Version:          aws.String("1"),
+	}
+
+	definition = launchDefinition{
+		launchTemplate: newLaunchTemplate,
+	}
+	result = r.requiresRefresh(ruObj, &mockInstance, &definition)
+	g.Expect(result).To(gomega.Equal(true))
+
+	// If launchTemplares are identical AND forceRefresh is false, requiresRefresh should return false
+	ruObj.Spec.ForceRefresh = false
+	result = r.requiresRefresh(ruObj, &mockInstance, &definition)
+	g.Expect(result).To(gomega.Equal(false))
+
+	// If launchConfigs are identical but forceRefresh is true, requiresRefresh should return true
+	ruObj.Spec.ForceRefresh = true
+	launchConfig := "launch-config"
+	mockInstance = autoscaling.Instance{InstanceId: &mockID, LaunchConfigurationName: &launchConfig, AvailabilityZone: &az}
+	definition = launchDefinition{
+		launchConfigurationName: &launchConfig,
+	}
+	result = r.requiresRefresh(ruObj, &mockInstance, &definition)
+	g.Expect(result).To(gomega.Equal(true))
+
+	// If launchConfigs are identical AND forceRefresh is false, requiresRefresh should return false
+	ruObj.Spec.ForceRefresh = false
+	result = r.requiresRefresh(ruObj, &mockInstance, &definition)
 	g.Expect(result).To(gomega.Equal(false))
 }
 


### PR DESCRIPTION
This commit enables force refreshing of nodes even if the launch-config or launch-template
has not changed.

Testing Done:
- Unit tests
- Ran default configuration with change to launch-config. Verified that the rolling upgrade
  happened and succeeded.
- Ran default config without change to launch-config. Verified that the controller detected
  the identical configs and did not perform node rotation.
- Enabled forceRefresh. Verified that nodes were rotated.

Closes #90