### PR TITLE
set firsttimestamp and count

### DIFF
--- a/.semaphore/setup.sh
+++ b/.semaphore/setup.sh
@@ -7,7 +7,7 @@ export arch=$(go env GOARCH)
 
 # https://semaphoreci.com/docs/how-to-increase-the-amount-of-available-memory.html
 sudo swapoff -a
-sudo dd if=/dev/zero of=/swapfile bs=1M count=1024
+sudo dd if=/dev/zero of=/swapfile bs=1M count=2048
 sudo mkswap /swapfile
 sudo swapon /swapfile
 

--- a/controllers/events.go
+++ b/controllers/events.go
@@ -40,7 +40,7 @@ func (r *RollingUpgradeReconciler) createK8sV1Event(objMeta *upgrademgrv1alpha1.
 	// UnsupportedTypeError or UnsupportedValueError. Since our type is very rigid, these errors won't be triggered.
 	b, _ := json.Marshal(msgFields)
 	msgPayload := string(b)
-
+	t := metav1.Time{Time: time.Now()}
 	event := &v1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%v-%v.%v", objMeta.Name, time.Now().Unix(), rand.Int()),
@@ -57,12 +57,12 @@ func (r *RollingUpgradeReconciler) createK8sV1Event(objMeta *upgrademgrv1alpha1.
 			APIVersion:      upgrademgrv1alpha1.GroupVersion.Version,
 			UID:             objMeta.UID,
 		},
-		Reason:  string(reason),
-		Message: msgPayload,
-		Type:    level,
-		LastTimestamp: metav1.Time{
-			Time: time.Now(),
-		},
+		Reason:         string(reason),
+		Message:        msgPayload,
+		Type:           level,
+		Count:          1,
+		FirstTimestamp: t,
+		LastTimestamp:  t,
 	}
 
 	log.Debugf("Publishing event: %v", event)


### PR DESCRIPTION
* set firsttimestamp and count in v1.Event
* bump up swapfile size to 2G

### crd.yaml
```
apiVersion: upgrademgr.keikoproj.io/v1alpha1
kind: RollingUpgrade
metadata:
  name: test-rollup-foo1-bar2
  namespace: kube-system
spec:
  asgName: mpa-eks-play2-instance-manager-nodes
  nodeIntervalSeconds: 30
  postDrain: {}
  postDrainDelaySeconds: 30
  postDrainScript: |
    echo "Hello, postDrain!"
  postDrainWaitScript: |
    echo "Hello, postDrainWait!"
  postTerminate: {}
  postTerminateScript: |
    echo "Hello, postTerminate!"
  preDrain: {}
  region: us-west-2
  strategy:
    mode: eager
    drainTimeout: 60
    type: randomUpdate
    maxUnavailable: 3
```

### get events
```6m14s       Normal    RollingUpgradeStarted            rollingupgrade/test-rollup-foo1-bar2                       {"asgName":"mpa-eks-play2-instance-manager-nodes","msg":"Rolling Upgrade has started","status":"started","strategy":"randomUpdate"}
6m12s       Normal    RollingUpgradeInstanceStarted    rollingupgrade/test-rollup-foo1-bar2                       {"asgName":"mpa-eks-play2-instance-manager-nodes","msg":"Started Updating Instance i-01c7224ef2660007d, in AZ: us-west-2b","status":"in-progress","strategy":"randomUpdate"}
6m12s       Normal    RollingUpgradeInstanceStarted    rollingupgrade/test-rollup-foo1-bar2                       {"asgName":"mpa-eks-play2-instance-manager-nodes","msg":"Started Updating Instance i-04bd8deeb42ca6f1b, in AZ: us-west-2a","status":"in-progress","strategy":"randomUpdate"}
6m12s       Normal    RollingUpgradeInstanceStarted    rollingupgrade/test-rollup-foo1-bar2                       {"asgName":"mpa-eks-play2-instance-manager-nodes","msg":"Started Updating Instance i-00975d648711dbcf5, in AZ: us-west-2c","status":"in-progress","strategy":"randomUpdate"}
93s         Normal    RollingUpgradeInstanceFinished   rollingupgrade/test-rollup-foo1-bar2                       {"asgName":"mpa-eks-play2-instance-manager-nodes","msg":"Finished Updating Instance 1/3 (Errors=0)","status":"in-progress","strategy":"randomUpdate"}
33s         Normal    RollingUpgradeInstanceFinished   rollingupgrade/test-rollup-foo1-bar2                       {"asgName":"mpa-eks-play2-instance-manager-nodes","msg":"Finished Updating Instance 2/3 (Errors=0)","status":"in-progress","strategy":"randomUpdate"}
33s         Normal    RollingUpgradeInstanceFinished   rollingupgrade/test-rollup-foo1-bar2                       {"asgName":"mpa-eks-play2-instance-manager-nodes","msg":"Finished Updating Instance 3/3 (Errors=0)","status":"in-progress","strategy":"randomUpdate"}
33s         Normal    RollingUpgradeFinished           rollingupgrade/test-rollup-foo1-bar2                       {"asgName":"mpa-eks-play2-instance-manager-nodes","info":"Rolling Upgrade as finished (status=completed)","status":"completed","strategy":"randomUpdate"}```