### PR TITLE
Check for CR before updating each instance.

### DIFF
--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -1077,6 +1077,10 @@ func (r *RollingUpgradeReconciler) UpdateInstance(ctx *context.Context,
 		r.info(ruObj, "termination waiter completed but node is still joined, will proceed with upgrade", "nodeName", nodeName)
 	}
 
+	err = r.setStateTag(ruObj, targetInstanceID, "completed")
+	if err != nil {
+		r.info(ruObj, "Setting tag on the instance post termination failed.", "nodeName", nodeName)
+	}
 	ruObj.Status.NodesProcessed = ruObj.Status.NodesProcessed + 1
 	if err := r.Status().Update(*ctx, ruObj); err != nil {
 		// Check if the err is "StorageError: invalid object". If so, the object was deleted...

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -769,12 +769,12 @@ func (r *RollingUpgradeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 			r.info(ruObj, "Sync map with invalid entry for ", "name", ruObj.Name)
 		}
 	} else {
+		r.info(ruObj, "Adding obj to map: ", "name", ruObj.Name)
+		r.admissionMap.Store(ruObj.Name, "processing")
 		_, err := r.Process(&ctx, ruObj)
 		if err != nil {
 			r.error(ruObj, err, "Processing failed")
 		}
-		r.info(ruObj, "Adding obj to map: ", "name", ruObj.Name)
-		r.admissionMap.Store(ruObj.Name, "processing")
 	}
 
 	if err = r.Update(ctx, ruObj); err != nil {

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -774,12 +774,9 @@ func (r *RollingUpgradeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	} else {
 		r.info(ruObj, "Adding obj to map: ", "name", ruObj.Name)
 		r.admissionMap.Store(ruObj.Name, "processing")
-		r.Process(&ctx, ruObj)
+		go r.Process(&ctx, ruObj)
 	}
 
-	if err = r.Update(ctx, ruObj); err != nil {
-		r.error(ruObj, err, "failed to update custom resource")
-	}
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -99,8 +99,7 @@ func TestErrorStatusMarkJanitor(t *testing.T) {
 	}
 
 	ctx := context.TODO()
-	_, err = rcRollingUpgrade.finishExecution(StatusError, 3, &ctx, instance)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	rcRollingUpgrade.finishExecution(StatusError, 3, &ctx, instance)
 	g.Expect(instance.ObjectMeta.Annotations[JanitorAnnotation]).To(gomega.Equal(ClearErrorFrequency))
 }
 
@@ -880,9 +879,7 @@ func TestFinishExecutionCompleted(t *testing.T) {
 	ctx := context.TODO()
 	mockNodesProcessed := 3
 
-	result, err := rcRollingUpgrade.finishExecution(StatusComplete, mockNodesProcessed, &ctx, ruObj)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(result).To(gomega.Not(gomega.BeNil()))
+	rcRollingUpgrade.finishExecution(StatusComplete, mockNodesProcessed, &ctx, ruObj)
 
 	g.Expect(ruObj.Status.CurrentStatus).To(gomega.Equal(StatusComplete))
 	g.Expect(ruObj.Status.NodesProcessed).To(gomega.Equal(mockNodesProcessed))
@@ -919,9 +916,7 @@ func TestFinishExecutionError(t *testing.T) {
 	ctx := context.TODO()
 	mockNodesProcessed := 3
 
-	result, err := rcRollingUpgrade.finishExecution(StatusError, mockNodesProcessed, &ctx, ruObj)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(result).To(gomega.Not(gomega.BeNil()))
+	rcRollingUpgrade.finishExecution(StatusError, mockNodesProcessed, &ctx, ruObj)
 
 	g.Expect(ruObj.Status.CurrentStatus).To(gomega.Equal(StatusError))
 	g.Expect(ruObj.Status.NodesProcessed).To(gomega.Equal(mockNodesProcessed))

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -974,6 +974,7 @@ func TestRunRestackSuccessOneNode(t *testing.T) {
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
+	rcRollingUpgrade.admissionMap.Store(ruObj.Name, "processing")
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
 	ctx := context.TODO()
@@ -1025,6 +1026,7 @@ func TestRunRestackSuccessMultipleNodes(t *testing.T) {
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
+	rcRollingUpgrade.admissionMap.Store(ruObj.Name, "processing")
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
 	ctx := context.TODO()
@@ -1064,6 +1066,7 @@ func TestRunRestackSameLaunchConfig(t *testing.T) {
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
+	rcRollingUpgrade.admissionMap.Store(ruObj.Name, "processing")
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
 	ctx := context.TODO()
@@ -1126,6 +1129,7 @@ func TestRunRestackRollingUpgradeNodeNameNotFound(t *testing.T) {
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
+	rcRollingUpgrade.admissionMap.Store(ruObj.Name, "processing")
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
 	ctx := context.TODO()
@@ -1174,6 +1178,7 @@ func TestRunRestackNoNodeName(t *testing.T) {
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
+	rcRollingUpgrade.admissionMap.Store(ruObj.Name, "processing")
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
 	ctx := context.TODO()
@@ -1239,6 +1244,7 @@ func TestRunRestackDrainNodeFail(t *testing.T) {
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
+	rcRollingUpgrade.admissionMap.Store(ruObj.Name, "processing")
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
 	ctx := context.TODO()
@@ -1300,6 +1306,7 @@ func TestRunRestackTerminateNodeFail(t *testing.T) {
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
+	rcRollingUpgrade.admissionMap.Store(ruObj.Name, "processing")
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
 	ctx := context.TODO()
@@ -1393,6 +1400,7 @@ func TestUniformAcrossAzUpdateSuccessMultipleNodes(t *testing.T) {
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
+	rcRollingUpgrade.admissionMap.Store(ruObj.Name, "processing")
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
 	ctx := context.TODO()
@@ -1451,6 +1459,7 @@ func TestUpdateInstances(t *testing.T) {
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
+	rcRollingUpgrade.admissionMap.Store(ruObj.Name, "processing")
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
 	ctx := context.TODO()
@@ -1516,6 +1525,7 @@ func TestUpdateInstancesError(t *testing.T) {
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
+	rcRollingUpgrade.admissionMap.Store(ruObj.Name, "processing")
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
 	ctx := context.TODO()
@@ -1588,6 +1598,7 @@ func TestUpdateInstancesPartialError(t *testing.T) {
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
+	rcRollingUpgrade.admissionMap.Store(ruObj.Name, "processing")
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
 	ctx := context.TODO()
@@ -2237,6 +2248,7 @@ func TestRunRestackNoNodeInAsg(t *testing.T) {
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
+	rcRollingUpgrade.admissionMap.Store(ruObj.Name, "processing")
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
 
 	ctx := context.TODO()

--- a/controllers/rollup_cluster_state.go
+++ b/controllers/rollup_cluster_state.go
@@ -17,8 +17,9 @@ limitations under the License.
 package controllers
 
 import (
-	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"sync"
+
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 )
 
 const (
@@ -72,9 +73,14 @@ func (c *ClusterStateImpl) markUpdateInProgress(instanceId string) {
 	c.updateInstanceState(instanceId, updateInProgress)
 }
 
-// markUpdateCompleted updates the instance state to completed
+// markUpdateCompleted updates the instance state to completed iff it is in-progress
 func (c *ClusterStateImpl) markUpdateCompleted(instanceId string) {
-	c.updateInstanceState(instanceId, updateCompleted)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.instanceUpdateInProgress(instanceId) {
+		c.updateInstanceState(instanceId, updateCompleted)
+	}
 }
 
 // instanceUpdateInProgress returns true if the instance update is in progress

--- a/controllers/rollup_cluster_state_test.go
+++ b/controllers/rollup_cluster_state_test.go
@@ -40,6 +40,7 @@ func TestMarkUpdateCompleted(t *testing.T) {
 
 	populateClusterState()
 	mockNodeName := "instance-1"
+	clusterState.markUpdateInProgress(mockNodeName)
 	clusterState.markUpdateCompleted(mockNodeName)
 
 	g.Expect(clusterState.instanceUpdateCompleted(mockNodeName)).To(gomega.BeTrue())

--- a/controllers/uniform_across_az_node_selector_test.go
+++ b/controllers/uniform_across_az_node_selector_test.go
@@ -96,6 +96,8 @@ func TestUniformAcrossAzNodeSelectorSelectNodesOneAzComplete(t *testing.T) {
 
 	clusterState := NewClusterState()
 	clusterState.initializeAsg(*mockAsg.AutoScalingGroupName, mockAsg.Instances)
+	clusterState.markUpdateInProgress(mockID + "1-" + az)
+	clusterState.markUpdateInProgress(mockID + "1-" + az2)
 	clusterState.markUpdateCompleted(mockID + "1-" + az)
 	clusterState.markUpdateCompleted(mockID + "1-" + az2)
 


### PR DESCRIPTION
Commits:

---
  This commit introduces the inProcessASGs map for keeping track of which ASGs are being processed. If an ASG is being processed and a new CR is submitted for the same ASG, the new CR get requeued until the first one is completed.

    This takes care of the case when a CR is deleted in the middle of doing rolling-upgrade. If the CR is deleted, no new instances will get drained and terminated. The ones in the middle of drain and terminate will be completed.

    Testing Done:

    - Adjusted unit tests for the new code. Ensured that unit tests complete successfully.
    - Deleted rollup CR when it was in the middle of being processed. Ensured that the CR completed the node that was being processed. Others nodes were ignored correctly.
    - Deleted rollup CR after it was completed. Ensured that it was deleted.
---

    Ignore "Invalid object" errors during status update.

    These errors are thrown if the CR is deleted while it was being processed. Unfortunately, there is no way other than error string comparison for doing this.

    Testing Done:

    - Unit tests succeed.
    - Started an upgrade. Deleted the CR while being processed. Verified that the correct log messages were logged and the controller didn't crash.

---

    Check admissionMap for every UpdateInstance

    This commit adds a check for an entry in the admissionMap during every UpdateInstance run. If the CR is deleted, the entry for it is removed from the admissionMap. And any calls to UpdateInstance from then on get short-circuited.

    Testing Done:
    - Unit tests passed
    - Basic rolling upgrade worked as expected.

---

    Move the code for checking CR deletion into Reconcile

    This commit moves the code for handling CR deletion from Process() to Reconcile(). If a CR is deleted while it is being processed, the Reconcile() method will be called and the CR is removed from the admissionMap. This will enable the asynchronously running Process() to check whether the CR is deleted periodically.

    Testing Done:

    - Unit tests pass.
    - Created a CR. While it was processing, delete it. Ensured that the code for handling the delete succeeded.

---

    Make Process run asynchronously

    This enables the Reconcile() to be called again. If and when the CR gets modified/deleted, the Reconcile() can now be called and appropriate actions can be taken.

    Testing Done:

    - Unit tests pass
    - Tested basic rolling-upgrade.

---

    Remove return values from "Process()"

    This is in preparation for calling Process() in a go-routine.

    Testing Done:
    - Unit tests pass.

---

    Add rolling upgrade CR name to admissionMap before processing starts

    This ensures that the admissionMap could be used in subsequent go-routines. In later commits, the admissionMap will be updated to indicate that the CR has been deleted. The go-routines that update the instances will check this and choose to proceed or not.

    Testing Done:

    - Unit tests pass. Ran a simple upgrade. It succeeded.

---

    Mark an instance as "completed" iff it was "in-progress"

    If an instance was started to get updated, it was marked "in-progress". However, there are cases when the instance is never marked "completed". This commit fixes that.

    All instance are marked "completed" if they started their upgrade.

    Testing Done:

    - Unit tests for this exist. Modified them to confirm expected behavior.
Closes #95