### PR TITLE
Fix log arguments for 0 node ASGs

### DIFF
--- a/.semaphore/setup.sh
+++ b/.semaphore/setup.sh
@@ -7,7 +7,7 @@ export arch=$(go env GOARCH)
 
 # https://semaphoreci.com/docs/how-to-increase-the-amount-of-available-memory.html
 sudo swapoff -a
-sudo dd if=/dev/zero of=/swapfile bs=1M count=2048
+sudo dd if=/dev/zero of=/swapfile bs=1M count=4096
 sudo mkswap /swapfile
 sudo swapon /swapfile
 

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -120,7 +120,7 @@ func (r *RollingUpgradeReconciler) runScript(script string, background bool, ruO
 		r.info(ruObj, "Running script in background. Logs not available.")
 		err := exec.Command(ShellBinary, "-c", script).Run()
 		if err != nil {
-			r.info(ruObj, "Script finished with error: %s", err)
+			r.info(ruObj, fmt.Sprintf("Script finished with error: %s", err))
 		}
 
 		return "", nil
@@ -535,11 +535,10 @@ func (r *RollingUpgradeReconciler) runRestack(ctx *context.Context, ruObj *upgra
 
 	r.info(ruObj, "Nodes in ASG that *might* need to be updated", "asgName", *asg.AutoScalingGroupName, "asgSize", len(asg.Instances))
 
-	// No further processing is required if ASG doesn't have an instance running
 	totalNodes := len(asg.Instances)
 	// No further processing is required if ASG doesn't have an instance running
 	if totalNodes == 0 {
-		r.info(ruObj, "Total nodes found for %s is 0", ruObj.Name)
+		r.info(ruObj, fmt.Sprintf("Total nodes needing update for %s is 0. Restack complete.", *asg.AutoScalingGroupName))
 		return 0, nil
 	}
 


### PR DESCRIPTION
This commit fixes the arguments sent to the logger when logging a message about 0 nodes in the ASG. Prior to this commit, there were odd number of arguments in the call and caused it to crash. After the change, the log message is logged correctly.

Testing Done:

- Reproduced the problem reported in #104. Found the controller crashing. Changed the docker image to a new one which included this fix.
- Verified that the fix worked as expected.

Closes #104