### PR TITLE
Upgrade to Go 1.15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: golangci/golangci-lint-action@v1
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.29
+        version: v1.32
         args: --timeout 2m
 
     - name: Get kubebuilder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.14.1 as builder
+FROM golang:1.15.3 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keikoproj/upgrade-manager
 
-go 1.13
+go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.33.8


### PR DESCRIPTION
Bump version of go to the latest support. 
No new issues found during testing.