### PR TITLE
If instance is in standby mode already, just return

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -85,7 +85,7 @@ func getInServiceIds(instances []*autoscaling.Instance) []string {
 	return list
 }
 
-func getGroupInstanceState(group *autoscaling.Group, instanceID string) (string, error) {
+func getInstanceStateInASG(group *autoscaling.Group, instanceID string) (string, error) {
 	for _, instance := range group.Instances {
 		if aws.StringValue(instance.InstanceId) == instanceID {
 			return aws.StringValue(instance.LifecycleState), nil


### PR DESCRIPTION
Saw several times repetitive message about unable to set instance state to standby because it is already in standby.

Other changes:
*  move input creation closer to the usage.
* rename function to improve readability.