### PR TITLE
Add Expiration to cache and do not refresh ASG if cache is not expired

### DIFF
--- a/controllers/events_test.go
+++ b/controllers/events_test.go
@@ -7,7 +7,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	log2 "sigs.k8s.io/controller-runtime/pkg/log"
-	"sync"
 	"testing"
 	"time"
 )
@@ -26,8 +25,6 @@ func Test_createK8sV1Event(t *testing.T) {
 		ASGClient:       MockAutoscalingGroup{},
 		EC2Client:       MockEC2{},
 		generatedClient: kubernetes.NewForConfigOrDie(mgr.GetConfig()),
-		admissionMap:    sync.Map{},
-		ruObjNameToASG:  sync.Map{},
 		ClusterState:    NewClusterState(),
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 		ScriptRunner:    NewScriptRunner(log2.NullLogger{}),

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -85,6 +85,8 @@ var (
 	WaiterFactor = 0.5
 	// WaiterMaxAttempts is the maximum number of retries for waiters
 	WaiterMaxAttempts = uint32(32)
+	// CacheTTL is ttl for ASG cache.
+	CacheTTL = 30 * time.Second
 )
 
 // RollingUpgradeReconciler reconciles a RollingUpgrade object
@@ -97,11 +99,46 @@ type RollingUpgradeReconciler struct {
 	NodeList        *corev1.NodeList
 	inProcessASGs   sync.Map
 	admissionMap    sync.Map
-	ruObjNameToASG  sync.Map
+	ruObjNameToASG  AsgCache
 	ClusterState    ClusterState
 	maxParallel     int
 	CacheConfig     *cache.Config
 	ScriptRunner    ScriptRunner
+}
+
+type AsgCache struct {
+	cache sync.Map
+}
+
+func (c *AsgCache) IsExpired(name string) bool {
+	if val, ok := c.cache.Load(name); !ok {
+		return true
+	} else {
+		cached := val.(CachedValue)
+		return time.Now().After(cached.expiration)
+	}
+}
+
+func (c *AsgCache) Load(name string) (*autoscaling.Group, bool) {
+	if val, ok := c.cache.Load(name); !ok {
+		return nil, false
+	} else {
+		cached := val.(CachedValue)
+		return cached.val.(*autoscaling.Group), true
+	}
+}
+
+func (c *AsgCache) Store(name string, asg *autoscaling.Group) {
+	c.cache.Store(name, CachedValue{asg, time.Now().Add(CacheTTL)})
+}
+
+func (c *AsgCache) Delete(name string) {
+	c.cache.Delete(name)
+}
+
+type CachedValue struct {
+	val        interface{}
+	expiration time.Time
 }
 
 func (r *RollingUpgradeReconciler) SetMaxParallel(max int) {
@@ -287,13 +324,11 @@ func (r *RollingUpgradeReconciler) WaitForTermination(ruObj *upgrademgrv1alpha1.
 }
 
 func (r *RollingUpgradeReconciler) GetAutoScalingGroup(rollupName string) (*autoscaling.Group, error) {
-	asg := &autoscaling.Group{}
 	val, ok := r.ruObjNameToASG.Load(rollupName)
 	if !ok {
-		return asg, fmt.Errorf("Unable to load ASG with name: %s", rollupName)
+		return &autoscaling.Group{}, fmt.Errorf("Unable to load ASG with name: %s", rollupName)
 	}
-	asg = val.(*autoscaling.Group)
-	return asg, nil
+	return val, nil
 }
 
 // SetStandby sets the autoscaling instance to standby mode.
@@ -391,6 +426,11 @@ func (r *RollingUpgradeReconciler) getNodeFromAsg(i *autoscaling.Instance, nodeL
 }
 
 func (r *RollingUpgradeReconciler) populateAsg(ruObj *upgrademgrv1alpha1.RollingUpgrade) error {
+	// if value is still in cache, do nothing.
+	if !r.ruObjNameToASG.IsExpired(ruObj.Name) {
+		return nil
+	}
+
 	input := &autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []*string{
 			aws.String(ruObj.Spec.AsgName),


### PR DESCRIPTION
Fixes #142.

Cache describe ASG result for 30 seconds.

Tested and confirmed working:

```
upgrade-manager-64b4c5c4c4-7hrq2 rolling-upgrade-controller {"level":"info","ts":1605568070.963403,"logger":"controllers.RollingUpgrade","msg":"Setting to stand-by","rollingupgrade":"rollingupgrade-node-us-west-2a","rollingupgrade-node-us-west-2a":"i-034833b8adb249eb1"}
upgrade-manager-64b4c5c4c4-7hrq2 rolling-upgrade-controller {"level":"info","ts":1605568071.1821046,"logger":"controllers.RollingUpgrade","msg":"reusing cached ASG info.","rollingupgrade":"rollingupgrade-node-us-west-2a"}
upgrade-manager-64b4c5c4c4-7hrq2 rolling-upgrade-controller {"level":"info","ts":1605568071.182137,"logger":"controllers.RollingUpgrade","msg":"desired capacity is met","rollingupgrade":"rollingupgrade-node-us-west-2a","inServiceCount":12}
upgrade-manager-64b4c5c4c4-7hrq2 rolling-upgrade-controller {"level":"info","ts":1605568071.182148,"logger":"controllers.RollingUpgrade","msg":"reusing cached ASG info.","rollingupgrade":"rollingupgrade-node-us-west-2a"}
upgrade-manager-64b4c5c4c4-7hrq2 rolling-upgrade-controller {"level":"info","ts":1605568071.1838853,"logger":"controllers.RollingUpgrade","msg":"reusing cached ASG info.","rollingupgrade":"rollingupgrade-node-us-west-2a"}
upgrade-manager-64b4c5c4c4-7hrq2 rolling-upgrade-controller {"level":"info","ts":1605568071.183909,"logger":"controllers.RollingUpgrade","msg":"desired capacity is met","rollingupgrade":"rollingupgrade-node-us-west-2a","inServiceCount":12}
upgrade-manager-64b4c5c4c4-7hrq2 rolling-upgrade-controller {"level":"info","ts":1605568071.1839197,"logger":"controllers.RollingUpgrade","msg":"reusing cached ASG info.","rollingupgrade":"rollingupgrade-node-us-west-2a"}
upgrade-manager-64b4c5c4c4-7hrq2 rolling-upgrade-controller {"level":"info","ts":1605568071.1840265,"logger":"controllers.RollingUpgrade","msg":"reusing cached ASG info.","rollingupgrade":"rollingupgrade-node-us-west-2a"}
upgrade-manager-64b4c5c4c4-7hrq2 rolling-upgrade-controller {"level":"info","ts":1605568071.1840456,"logger":"controllers.RollingUpgrade","msg":"desired capacity is met","rollingupgrade":"rollingupgrade-node-us-west-2a","inServiceCount":12}
upgrade-manager-64b4c5c4c4-7hrq2 rolling-upgrade-controller {"level":"info","ts":1605568071.1840522,"logger":"controllers.RollingUpgrade","msg":"reusing cached ASG info.","rollingupgrade":"rollingupgrade-node-us-west-2a"}
upgrade-manager-64b4c5c4c4-7hrq2 rolling-upgrade-controller {"level":"info","ts":1605568071.7543626,"logger":"controllers.RollingUpgrade","msg":"desired capacity is met","rollingupgrade":"rollingupgrade-node-us-west-2a","inServiceCount":12}
```

I'll remove logging before merge.

Signed-off-by: Oleg Atamanenko <oleg.atamanenko@gmail.com>