### PR TITLE
Propagate parent env variables to allow to talk with API Server

### DIFF
--- a/controllers/script_runner.go
+++ b/controllers/script_runner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-logr/logr"
 	upgrademgrv1alpha1 "github.com/keikoproj/upgrade-manager/api/v1alpha1"
 	"github.com/pkg/errors"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -60,7 +61,7 @@ func (r *ScriptRunner) runScriptWithEnv(script string, background bool, ruObj *u
 	r.info(ruObj, "Running script", "script", script)
 	command := exec.Command(ShellBinary, "-c", script)
 	if env != nil {
-		command.Env = env
+		command.Env = append(os.Environ(), env...)
 	}
 
 	if background {


### PR DESCRIPTION
Discovered that new script runner doesn't propagate env variables from parent process. It prevents to talk to API Server from scripts. This PR fixes it. Related to #132 