### PR TITLE
Bump Golang CI action to fix failed CI run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Golangci-lint
-      uses: golangci/golangci-lint-action@v1
+      uses: golangci/golangci-lint-action@v2
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
         version: v1.32


### PR DESCRIPTION
Bumping golang ci action fixes PR builds
Extracting as a separate PR.