### PR TITLE
Move cluster state from package level to a cluster state impl

### DIFF
--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -281,7 +281,7 @@ func TestGetNextAvailableInstance(t *testing.T) {
 	available := getNextAvailableInstances(mockAsgName, 1, instancesList, rcRollingUpgrade.ClusterState)
 
 	g.Expect(1).Should(gomega.Equal(len(available)))
-	g.Expect(rcRollingUpgrade.ClusterState.deleteEntryOfAsg(mockAsgName)).To(gomega.BeTrue())
+	g.Expect(rcRollingUpgrade.ClusterState.deleteAllInstancesInAsg(mockAsgName)).To(gomega.BeTrue())
 
 }
 
@@ -302,7 +302,7 @@ func TestGetNextAvailableInstanceNoInstanceFound(t *testing.T) {
 	available := getNextAvailableInstances("asg2", 1, instancesList, rcRollingUpgrade.ClusterState)
 
 	g.Expect(0).Should(gomega.Equal(len(available)))
-	g.Expect(rcRollingUpgrade.ClusterState.deleteEntryOfAsg(mockAsgName)).To(gomega.BeTrue())
+	g.Expect(rcRollingUpgrade.ClusterState.deleteAllInstancesInAsg(mockAsgName)).To(gomega.BeTrue())
 
 }
 
@@ -333,7 +333,7 @@ func TestGetNextAvailableInstanceInAz(t *testing.T) {
 	instances = getNextSetOfAvailableInstancesInAz(mockAsgName, "az3", 1, instancesList, rcRollingUpgrade.ClusterState)
 	g.Expect(0).Should(gomega.Equal(len(instances)))
 
-	g.Expect(rcRollingUpgrade.ClusterState.deleteEntryOfAsg(mockAsgName)).To(gomega.BeTrue())
+	g.Expect(rcRollingUpgrade.ClusterState.deleteAllInstancesInAsg(mockAsgName)).To(gomega.BeTrue())
 
 }
 
@@ -359,5 +359,5 @@ func TestGetNextAvailableInstanceInAzGetMultipleInstances(t *testing.T) {
 	instanceIds := []string{*instances[0].InstanceId, *instances[1].InstanceId}
 	g.Expect(instanceIds).Should(gomega.ConsistOf(mockInstanceName1, mockInstanceName2))
 
-	g.Expect(rcRollingUpgrade.ClusterState.deleteEntryOfAsg(mockAsgName)).To(gomega.BeTrue())
+	g.Expect(rcRollingUpgrade.ClusterState.deleteAllInstancesInAsg(mockAsgName)).To(gomega.BeTrue())
 }

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -501,7 +501,7 @@ func (r *RollingUpgradeReconciler) runRestack(ctx *context.Context, ruObj *upgra
 
 	r.inProcessASGs.Store(*asg.AutoScalingGroupName, "running")
 	r.ClusterState.initializeAsg(*asg.AutoScalingGroupName, asg.Instances)
-	defer r.ClusterState.deleteEntryOfAsg(*asg.AutoScalingGroupName)
+	defer r.ClusterState.deleteAllInstancesInAsg(*asg.AutoScalingGroupName)
 
 	launchDefinition := NewLaunchDefinition(asg)
 
@@ -589,7 +589,7 @@ func (r *RollingUpgradeReconciler) finishExecution(finalStatus string, nodesProc
 		}
 	}
 
-	r.ClusterState.deleteEntryOfAsg(ruObj.Spec.AsgName)
+	r.ClusterState.deleteAllInstancesInAsg(ruObj.Spec.AsgName)
 	r.info(ruObj, "Deleted the entries of ASG in the cluster store", "asgName", ruObj.Spec.AsgName)
 	r.inProcessASGs.Delete(ruObj.Spec.AsgName)
 	r.admissionMap.Delete(ruObj.Name)

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -2359,7 +2359,7 @@ func TestRunRestackWithNodesLessThanMaxUnavailable(t *testing.T) {
 		CacheConfig:     cache.NewConfig(0*time.Second, 0, 0),
 	}
 	rcRollingUpgrade.ruObjNameToASG.Store(ruObj.Name, &mockAsg)
-	rcRollingUpgrade.ClusterState.deleteEntryOfAsg(someAsg)
+	rcRollingUpgrade.ClusterState.deleteAllInstancesInAsg(someAsg)
 	ctx := context.TODO()
 
 	// This execution should not perform drain or termination, but should pass

--- a/controllers/rollup_cluster_state_test.go
+++ b/controllers/rollup_cluster_state_test.go
@@ -109,8 +109,8 @@ func TestDeleteEntryOfAsg(t *testing.T) {
 	populateClusterState()
 	mockAsgName := "asg-1"
 
-	g.Expect(clusterState.deleteEntryOfAsg(mockAsgName)).To(gomega.BeTrue())
-	g.Expect(clusterState.deleteEntryOfAsg(mockAsgName)).To(gomega.BeFalse())
+	g.Expect(clusterState.deleteAllInstancesInAsg(mockAsgName)).To(gomega.BeTrue())
+	g.Expect(clusterState.deleteAllInstancesInAsg(mockAsgName)).To(gomega.BeFalse())
 }
 
 func TestInstanceStateUpdateSequence(t *testing.T) {
@@ -126,8 +126,8 @@ func TestInstanceStateUpdateSequence(t *testing.T) {
 	clusterState.markUpdateCompleted(mockNodeName)
 	g.Expect(clusterState.instanceUpdateCompleted(mockNodeName)).To(gomega.BeTrue())
 
-	g.Expect(clusterState.deleteEntryOfAsg(mockAsgName)).To(gomega.BeTrue())
-	g.Expect(clusterState.deleteEntryOfAsg(mockAsgName)).To(gomega.BeFalse())
+	g.Expect(clusterState.deleteAllInstancesInAsg(mockAsgName)).To(gomega.BeTrue())
+	g.Expect(clusterState.deleteAllInstancesInAsg(mockAsgName)).To(gomega.BeFalse())
 }
 
 func TestGetNextAvailableInstanceIdInAz(t *testing.T) {


### PR DESCRIPTION
Found out that cluster state was public at package level, move it to a ClusterState and make it private.
Other changes: improve code readability.