### PR TITLE
Simplify work with intstr type.

### DIFF
--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -1,9 +1,8 @@
 package controllers
 
 import (
-	"encoding/json"
-	"fmt"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/aws/aws-sdk-go/aws"
 
@@ -17,13 +16,9 @@ import (
 func TestGetMaxUnavailableWithPercentageValue(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	jsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": \"75%\", \"drainTimeout\": 15 }"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(jsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		MaxUnavailable: intstr.Parse("75%"),
 	}
-
 	g.Expect(getMaxUnavailable(strategy, 200)).To(gomega.Equal(150))
 }
 
@@ -214,13 +209,9 @@ func TestGetInServiceIds(t *testing.T) {
 func TestGetMaxUnavailableWithPercentageValue33(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	jsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": \"67%\", \"drainTimeout\": 15 }"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(jsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		MaxUnavailable: intstr.Parse("67%"),
 	}
-
 	g.Expect(getMaxUnavailable(strategy, 3)).To(gomega.Equal(2))
 }
 
@@ -228,39 +219,27 @@ func TestGetMaxUnavailableWithPercentageAndSingleInstance(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	totalNodes := 1
-	jsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": \"67%\", \"drainTimeout\": 15 }"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(jsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		MaxUnavailable: intstr.Parse("67%"),
 	}
-
 	g.Expect(getMaxUnavailable(strategy, totalNodes)).To(gomega.Equal(1))
 }
 
 func TestGetMaxUnavailableWithPercentageNonIntResult(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	jsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": \"37%\", \"drainTimeout\": 15 }"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(jsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		MaxUnavailable: intstr.Parse("37%"),
 	}
-
 	g.Expect(getMaxUnavailable(strategy, 50)).To(gomega.Equal(18))
 }
 
 func TestGetMaxUnavailableWithIntValue(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	jsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": 75, \"drainTimeout\": 15 }"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(jsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		MaxUnavailable: intstr.Parse("75"),
 	}
-
 	g.Expect(getMaxUnavailable(strategy, 200)).To(gomega.Equal(75))
 }
 
@@ -274,8 +253,7 @@ func TestGetNextAvailableInstance(t *testing.T) {
 	instance1 := autoscaling.Instance{InstanceId: &mockInstanceName1, AvailabilityZone: &az}
 	instance2 := autoscaling.Instance{InstanceId: &mockInstanceName2, AvailabilityZone: &az}
 
-	instancesList := []*autoscaling.Instance{}
-	instancesList = append(instancesList, &instance1, &instance2)
+	instancesList := []*autoscaling.Instance{&instance1, &instance2}
 	rcRollingUpgrade := &RollingUpgradeReconciler{ClusterState: clusterState}
 	rcRollingUpgrade.ClusterState.initializeAsg(mockAsgName, instancesList)
 	available := getNextAvailableInstances(mockAsgName, 1, instancesList, rcRollingUpgrade.ClusterState)
@@ -295,8 +273,7 @@ func TestGetNextAvailableInstanceNoInstanceFound(t *testing.T) {
 	instance1 := autoscaling.Instance{InstanceId: &mockInstanceName1, AvailabilityZone: &az}
 	instance2 := autoscaling.Instance{InstanceId: &mockInstanceName2, AvailabilityZone: &az}
 
-	instancesList := []*autoscaling.Instance{}
-	instancesList = append(instancesList, &instance1, &instance2)
+	instancesList := []*autoscaling.Instance{&instance1, &instance2}
 	rcRollingUpgrade := &RollingUpgradeReconciler{ClusterState: clusterState}
 	rcRollingUpgrade.ClusterState.initializeAsg(mockAsgName, instancesList)
 	available := getNextAvailableInstances("asg2", 1, instancesList, rcRollingUpgrade.ClusterState)
@@ -317,8 +294,7 @@ func TestGetNextAvailableInstanceInAz(t *testing.T) {
 	instance1 := autoscaling.Instance{InstanceId: &mockInstanceName1, AvailabilityZone: &az}
 	instance2 := autoscaling.Instance{InstanceId: &mockInstanceName2, AvailabilityZone: &az2}
 
-	instancesList := []*autoscaling.Instance{}
-	instancesList = append(instancesList, &instance1, &instance2)
+	instancesList := []*autoscaling.Instance{&instance1, &instance2}
 	rcRollingUpgrade := &RollingUpgradeReconciler{ClusterState: clusterState}
 	rcRollingUpgrade.ClusterState.initializeAsg(mockAsgName, instancesList)
 
@@ -347,8 +323,7 @@ func TestGetNextAvailableInstanceInAzGetMultipleInstances(t *testing.T) {
 	instance1 := autoscaling.Instance{InstanceId: &mockInstanceName1, AvailabilityZone: &az}
 	instance2 := autoscaling.Instance{InstanceId: &mockInstanceName2, AvailabilityZone: &az}
 
-	instancesList := []*autoscaling.Instance{}
-	instancesList = append(instancesList, &instance1, &instance2)
+	instancesList := []*autoscaling.Instance{&instance1, &instance2}
 	rcRollingUpgrade := &RollingUpgradeReconciler{ClusterState: clusterState}
 	rcRollingUpgrade.ClusterState.initializeAsg(mockAsgName, instancesList)
 

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -816,16 +816,16 @@ func (r *RollingUpgradeReconciler) validateRollingUpgradeObj(ruObj *upgrademgrv1
 		return nil
 	}
 	// validating the maxUnavailable value
-	if strategy.MaxUnavailable.Type == 0 {
+	if strategy.MaxUnavailable.Type == intstr.Int {
 		if strategy.MaxUnavailable.IntVal <= 0 {
 			err := errors.New(fmt.Sprintf("%s: Invalid value for maxUnavailable - %d",
 				ruObj.Name, strategy.MaxUnavailable.IntVal))
 			r.error(ruObj, err, "Invalid value for maxUnavailable", "value", strategy.MaxUnavailable.IntVal)
 			return err
 		}
-	} else if strategy.MaxUnavailable.Type == 1 {
-		strVallue := strategy.MaxUnavailable.StrVal
-		intValue, _ := strconv.Atoi(strings.Trim(strVallue, "%"))
+	} else if strategy.MaxUnavailable.Type == intstr.String {
+		strVal := strategy.MaxUnavailable.StrVal
+		intValue, _ := strconv.Atoi(strings.Trim(strVal, "%"))
 		if intValue <= 0 || intValue > 100 {
 			err := errors.New(fmt.Sprintf("%s: Invalid value for maxUnavailable - %s",
 				ruObj.Name, strategy.MaxUnavailable.StrVal))
@@ -846,34 +846,19 @@ func (r *RollingUpgradeReconciler) validateRollingUpgradeObj(ruObj *upgrademgrv1
 
 // setDefaultsForRollingUpdateStrategy sets the default values for type, maxUnavailable and drainTimeout
 func (r *RollingUpgradeReconciler) setDefaultsForRollingUpdateStrategy(ruObj *upgrademgrv1alpha1.RollingUpgrade) {
-
-	// Setting the default values for the update strategy when strategy is not set
-	// Default behaviour should be to update one node at a time and should wait for kubectl drain completion
-	var nilStrategy = upgrademgrv1alpha1.UpdateStrategy{}
-	if ruObj.Spec.Strategy == nilStrategy {
-		r.info(ruObj, "Update strategy not set on the rollup object, setting the default strategy.")
-		strategy := upgrademgrv1alpha1.UpdateStrategy{
-			Type:           upgrademgrv1alpha1.RandomUpdateStrategy,
-			Mode:           upgrademgrv1alpha1.UpdateStrategyModeLazy,
-			MaxUnavailable: intstr.IntOrString{IntVal: 1},
-			DrainTimeout:   -1,
-		}
-		ruObj.Spec.Strategy = strategy
-	} else {
-		if ruObj.Spec.Strategy.Type == "" {
-			ruObj.Spec.Strategy.Type = upgrademgrv1alpha1.RandomUpdateStrategy
-		}
-		if ruObj.Spec.Strategy.Mode == "" {
-			// default to lazy mode
-			ruObj.Spec.Strategy.Mode = upgrademgrv1alpha1.UpdateStrategyModeLazy
-		}
-		// intstr.IntOrString has the default value 0 with int types
-		if ruObj.Spec.Strategy.MaxUnavailable.Type == 0 && ruObj.Spec.Strategy.MaxUnavailable.IntVal == 0 {
-			ruObj.Spec.Strategy.MaxUnavailable = intstr.IntOrString{Type: 0, IntVal: 1}
-		}
-		if ruObj.Spec.Strategy.DrainTimeout == 0 {
-			ruObj.Spec.Strategy.DrainTimeout = -1
-		}
+	if ruObj.Spec.Strategy.Type == "" {
+		ruObj.Spec.Strategy.Type = upgrademgrv1alpha1.RandomUpdateStrategy
+	}
+	if ruObj.Spec.Strategy.Mode == "" {
+		// default to lazy mode
+		ruObj.Spec.Strategy.Mode = upgrademgrv1alpha1.UpdateStrategyModeLazy
+	}
+	// Set default max unavailable to 1.
+	if ruObj.Spec.Strategy.MaxUnavailable.Type == intstr.Int && ruObj.Spec.Strategy.MaxUnavailable.IntVal == 0 {
+		ruObj.Spec.Strategy.MaxUnavailable.IntVal = 1
+	}
+	if ruObj.Spec.Strategy.DrainTimeout == 0 {
+		ruObj.Spec.Strategy.DrainTimeout = -1
 	}
 }
 

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1806,12 +1805,10 @@ func TestTestCallKubectlDrainWithTimeoutOccurring(t *testing.T) {
 func TestValidateRuObj(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": 75, \"drainTimeout\": 15 }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type:           upgrademgrv1alpha1.RandomUpdateStrategy,
+		MaxUnavailable: intstr.Parse("75"),
 	}
 
 	rcRollingUpgrade := createReconciler()
@@ -1823,19 +1820,17 @@ func TestValidateRuObj(t *testing.T) {
 		},
 	}
 
-	err = rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
+	err := rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
 	g.Expect(err).To(gomega.BeNil())
 }
 
 func TestValidateruObjInvalidMaxUnavailable(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": \"150%\", \"drainTimeout\": 15 }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type:           upgrademgrv1alpha1.RandomUpdateStrategy,
+		MaxUnavailable: intstr.Parse("150%"),
 	}
 
 	rcRollingUpgrade := createReconciler()
@@ -1847,19 +1842,17 @@ func TestValidateruObjInvalidMaxUnavailable(t *testing.T) {
 		},
 	}
 
-	err = rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
+	err := rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
 	g.Expect(err.Error()).To(gomega.ContainSubstring("Invalid value for maxUnavailable"))
 }
 
 func TestValidateruObjMaxUnavailableZeroPercent(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": \"0%\", \"drainTimeout\": 15 }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type:           upgrademgrv1alpha1.RandomUpdateStrategy,
+		MaxUnavailable: intstr.Parse("0%"),
 	}
 
 	rcRollingUpgrade := createReconciler()
@@ -1871,19 +1864,17 @@ func TestValidateruObjMaxUnavailableZeroPercent(t *testing.T) {
 		},
 	}
 
-	err = rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
+	err := rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
 	g.Expect(err.Error()).To(gomega.ContainSubstring("Invalid value for maxUnavailable"))
 }
 
 func TestValidateruObjMaxUnavailableInt(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": 10, \"drainTimeout\": 15 }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type:           upgrademgrv1alpha1.RandomUpdateStrategy,
+		MaxUnavailable: intstr.Parse("10"),
 	}
 
 	rcRollingUpgrade := createReconciler()
@@ -1895,19 +1886,17 @@ func TestValidateruObjMaxUnavailableInt(t *testing.T) {
 		},
 	}
 
-	err = rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
+	err := rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
 	g.Expect(err).To(gomega.BeNil())
 }
 
 func TestValidateruObjMaxUnavailableIntZero(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": 0, \"drainTimeout\": 15 }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type:           upgrademgrv1alpha1.RandomUpdateStrategy,
+		MaxUnavailable: intstr.Parse("0"),
 	}
 
 	rcRollingUpgrade := createReconciler()
@@ -1919,19 +1908,17 @@ func TestValidateruObjMaxUnavailableIntZero(t *testing.T) {
 		},
 	}
 
-	err = rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
+	err := rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
 	g.Expect(err.Error()).To(gomega.ContainSubstring("Invalid value for maxUnavailable"))
 }
 
 func TestValidateruObjMaxUnavailableIntNegativeValue(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": -1, \"drainTimeout\": 15 }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type:           upgrademgrv1alpha1.RandomUpdateStrategy,
+		MaxUnavailable: intstr.Parse("-1"),
 	}
 
 	rcRollingUpgrade := createReconciler()
@@ -1943,19 +1930,16 @@ func TestValidateruObjMaxUnavailableIntNegativeValue(t *testing.T) {
 		},
 	}
 
-	err = rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
+	err := rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
 	g.Expect(err.Error()).To(gomega.ContainSubstring("Invalid value for maxUnavailable"))
 }
 
 func TestValidateruObjWithStrategyAndDrainTimeoutOnly(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"randomUpdate\", \"drainTimeout\": 15 }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type: upgrademgrv1alpha1.RandomUpdateStrategy,
 	}
 
 	rcRollingUpgrade := createReconciler()
@@ -1967,21 +1951,17 @@ func TestValidateruObjWithStrategyAndDrainTimeoutOnly(t *testing.T) {
 		},
 	}
 
-	err = rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
+	err := rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
 	g.Expect(err.Error()).To(gomega.ContainSubstring("Invalid value for maxUnavailable"))
 }
 
 func TestValidateruObjWithoutStrategyOnly(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	RollingUpgradeJsonString := "{}"
 	ruObj := upgrademgrv1alpha1.RollingUpgrade{}
-	err := json.Unmarshal([]byte(RollingUpgradeJsonString), &ruObj)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling RollingUpgrade object, error: %s", err.Error())
-	}
+
 	rcRollingUpgrade := createReconciler()
-	err = rcRollingUpgrade.validateRollingUpgradeObj(&ruObj)
+	err := rcRollingUpgrade.validateRollingUpgradeObj(&ruObj)
 
 	g.Expect(err).To(gomega.BeNil())
 }
@@ -1989,12 +1969,10 @@ func TestValidateruObjWithoutStrategyOnly(t *testing.T) {
 func TestValidateruObjStrategyType(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": 10, \"drainTimeout\": 15 }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type:           upgrademgrv1alpha1.RandomUpdateStrategy,
+		MaxUnavailable: intstr.Parse("10"),
 	}
 
 	rcRollingUpgrade := createReconciler()
@@ -2006,19 +1984,17 @@ func TestValidateruObjStrategyType(t *testing.T) {
 		},
 	}
 
-	err = rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
+	err := rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
 	g.Expect(err).To(gomega.BeNil())
 }
 
 func TestValidateruObjInvalidStrategyType(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"xyz\", \"maxUnavailable\": 10, \"drainTimeout\": 15 }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type:           "xyx",
+		MaxUnavailable: intstr.Parse("10"),
 	}
 
 	rcRollingUpgrade := createReconciler()
@@ -2030,7 +2006,7 @@ func TestValidateruObjInvalidStrategyType(t *testing.T) {
 		},
 	}
 
-	err = rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
+	err := rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
 	g.Expect(err.Error()).To(gomega.ContainSubstring("Invalid value for strategy type"))
 }
 
@@ -2067,13 +2043,8 @@ func TestSetDefaultsForRollingUpdateStrategy(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ }"
 	mockAsgName := "some-asg"
 	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
-	}
 
 	rcRollingUpgrade := createReconciler()
 	ruObj := &upgrademgrv1alpha1.RollingUpgrade{
@@ -2093,12 +2064,9 @@ func TestSetDefaultsForRollingUpdateStrategy(t *testing.T) {
 func TestValidateruObjStrategyAfterSettingDefaults(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"randomUpdate\" }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type: upgrademgrv1alpha1.RandomUpdateStrategy,
 	}
 
 	rcRollingUpgrade := createReconciler()
@@ -2110,20 +2078,17 @@ func TestValidateruObjStrategyAfterSettingDefaults(t *testing.T) {
 		},
 	}
 	rcRollingUpgrade.setDefaultsForRollingUpdateStrategy(ruObj)
-	error := rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
+	err := rcRollingUpgrade.validateRollingUpgradeObj(ruObj)
 
-	g.Expect(error).To(gomega.BeNil())
+	g.Expect(err).To(gomega.BeNil())
 }
 
 func TestValidateruObjStrategyAfterSettingDefaultsWithInvalidStrategyType(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"xyz\" }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type: "xyz",
 	}
 
 	rcRollingUpgrade := createReconciler()
@@ -2143,12 +2108,10 @@ func TestValidateruObjStrategyAfterSettingDefaultsWithInvalidStrategyType(t *tes
 func TestValidateruObjStrategyAfterSettingDefaultsWithOnlyDrainTimeout(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"randomUpdate\", \"drainTimeout\": 15 }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type:         upgrademgrv1alpha1.RandomUpdateStrategy,
+		DrainTimeout: 15,
 	}
 
 	rcRollingUpgrade := createReconciler()
@@ -2168,12 +2131,10 @@ func TestValidateruObjStrategyAfterSettingDefaultsWithOnlyDrainTimeout(t *testin
 func TestValidateruObjStrategyAfterSettingDefaultsWithOnlyMaxUnavailable(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	strategyJsonString := "{ \"type\": \"randomUpdate\", \"maxUnavailable\": \"100%\" }"
 	mockAsgName := "some-asg"
-	strategy := upgrademgrv1alpha1.UpdateStrategy{}
-	err := json.Unmarshal([]byte(strategyJsonString), &strategy)
-	if err != nil {
-		fmt.Printf("Error occurred while unmarshalling strategy object, error: %s", err.Error())
+	strategy := upgrademgrv1alpha1.UpdateStrategy{
+		Type:           upgrademgrv1alpha1.RandomUpdateStrategy,
+		MaxUnavailable: intstr.Parse("100%"),
 	}
 
 	rcRollingUpgrade := createReconciler()


### PR DESCRIPTION
Use API provided by `intstr` package to simplify code and tests.