### PR TITLE
Don't uncordon node on failure to run postDrain script when IgnoreDrainFailures set

### DIFF
--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -143,7 +144,8 @@ func TestPostDrainHelperPostDrainScriptSuccess(t *testing.T) {
 func TestPostDrainHelperPostDrainScriptError(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	mockNode := "some-node-name"
-	mockKubeCtlCall := "echo"
+	mockKubeCtlCall := "k() { echo $@ >> cmdlog.txt ; }; k"
+	os.Remove("cmdlog.txt")
 
 	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
 	ruObj.Spec.PostDrain.Script = "exit 1"
@@ -153,6 +155,34 @@ func TestPostDrainHelperPostDrainScriptError(t *testing.T) {
 	err := rcRollingUpgrade.postDrainHelper("test-instance-id", mockNode, ruObj)
 
 	g.Expect(err).To(gomega.Not(gomega.BeNil()))
+
+	// assert node was uncordoned
+	cmdlog, _ := ioutil.ReadFile("cmdlog.txt")
+	g.Expect(string(cmdlog)).To(gomega.Equal(fmt.Sprintf("uncordon %s\n", mockNode)))
+	os.Remove("cmdlog.txt")
+}
+
+func TestPostDrainHelperPostDrainScriptErrorWithIgnoreDrainFailures(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	mockNode := "some-node-name"
+	mockKubeCtlCall := "k() { echo $@ >> cmdlog.txt ; }; k"
+	os.Remove("cmdlog.txt")
+
+	ruObj := &upgrademgrv1alpha1.RollingUpgrade{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+		Spec: upgrademgrv1alpha1.RollingUpgradeSpec{IgnoreDrainFailures: true}}
+	ruObj.Spec.PostDrain.Script = "exit 1"
+
+	rcRollingUpgrade := createReconciler()
+	rcRollingUpgrade.ScriptRunner.KubectlCall = mockKubeCtlCall
+	err := rcRollingUpgrade.postDrainHelper("test-instance-id", mockNode, ruObj)
+
+	g.Expect(err).To(gomega.Not(gomega.BeNil()))
+
+	// assert node was not uncordoned
+	cmdlog, _ := ioutil.ReadFile("cmdlog.txt")
+	g.Expect(string(cmdlog)).To(gomega.Equal(""))
+	os.Remove("cmdlog.txt")
 }
 
 func TestPostDrainHelperPostDrainWaitScriptSuccess(t *testing.T) {
@@ -174,7 +204,8 @@ func TestPostDrainHelperPostDrainWaitScriptSuccess(t *testing.T) {
 func TestPostDrainHelperPostDrainWaitScriptError(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	mockNode := "some-node-name"
-	mockKubeCtlCall := "echo"
+	mockKubeCtlCall := "k() { echo $@ >> cmdlog.txt ; }; k"
+	os.Remove("cmdlog.txt")
 
 	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
 	ruObj.Spec.PostDrain.PostWaitScript = "exit 1"
@@ -185,6 +216,35 @@ func TestPostDrainHelperPostDrainWaitScriptError(t *testing.T) {
 	err := rcRollingUpgrade.postDrainHelper("test-instance-id", mockNode, ruObj)
 
 	g.Expect(err).To(gomega.Not(gomega.BeNil()))
+
+	// assert node was uncordoned
+	cmdlog, _ := ioutil.ReadFile("cmdlog.txt")
+	g.Expect(string(cmdlog)).To(gomega.Equal(fmt.Sprintf("uncordon %s\n", mockNode)))
+	os.Remove("cmdlog.txt")
+}
+
+func TestPostDrainHelperPostDrainWaitScriptErrorWithIgnoreDrainFailures(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	mockNode := "some-node-name"
+	mockKubeCtlCall := "k() { echo $@ >> cmdlog.txt ; }; k"
+	os.Remove("cmdlog.txt")
+
+	ruObj := &upgrademgrv1alpha1.RollingUpgrade{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+		Spec: upgrademgrv1alpha1.RollingUpgradeSpec{IgnoreDrainFailures: true}}
+	ruObj.Spec.PostDrain.PostWaitScript = "exit 1"
+	ruObj.Spec.PostDrainDelaySeconds = 0
+
+	rcRollingUpgrade := createReconciler()
+	rcRollingUpgrade.ScriptRunner.KubectlCall = mockKubeCtlCall
+	err := rcRollingUpgrade.postDrainHelper("test-instance-id", mockNode, ruObj)
+
+	g.Expect(err).To(gomega.Not(gomega.BeNil()))
+
+	// assert node was not uncordoned
+	cmdlog, _ := ioutil.ReadFile("cmdlog.txt")
+	g.Expect(string(cmdlog)).To(gomega.Equal(""))
+	os.Remove("cmdlog.txt")
 }
 
 func TestDrainNodeSuccess(t *testing.T) {

--- a/controllers/script_runner.go
+++ b/controllers/script_runner.go
@@ -159,11 +159,14 @@ func (r *ScriptRunner) PostDrain(instanceID string, nodeName string, ruObj *upgr
 			r.error(ruObj, err, msg)
 			result := errors.Wrap(err, msg)
 
-			r.info(ruObj, "Uncordoning the node %s since it failed to run postDrain Script", "nodeName", nodeName)
-			_, err = r.uncordonNode(nodeName, ruObj)
-			if err != nil {
-				r.error(ruObj, err, "Failed to uncordon", "nodeName", nodeName)
+			if !ruObj.Spec.IgnoreDrainFailures {
+				r.info(ruObj, "Uncordoning the node %s since it failed to run postDrain Script", "nodeName", nodeName)
+				_, err = r.uncordonNode(nodeName, ruObj)
+				if err != nil {
+					r.error(ruObj, err, "Failed to uncordon", "nodeName", nodeName)
+				}
 			}
+
 			return result
 		}
 	}

--- a/controllers/script_runner.go
+++ b/controllers/script_runner.go
@@ -140,11 +140,14 @@ func (r *ScriptRunner) PostWait(instanceID string, nodeName string, ruObj *upgra
 			r.error(ruObj, err, msg)
 			result := errors.Wrap(err, msg)
 
-			r.info(ruObj, "Uncordoning the node %s since it failed to run postDrain Script", "nodeName", nodeName)
-			_, err = r.uncordonNode(nodeName, ruObj)
-			if err != nil {
-				r.error(ruObj, err, "Failed to uncordon", "nodeName", nodeName)
+			if !ruObj.Spec.IgnoreDrainFailures {
+				r.info(ruObj, "Uncordoning the node %s since it failed to run postDrainWait Script", "nodeName", nodeName)
+				_, err = r.uncordonNode(nodeName, ruObj)
+				if err != nil {
+					r.error(ruObj, err, "Failed to uncordon", "nodeName", nodeName)
+				}
 			}
+
 			return result
 		}
 	}


### PR DESCRIPTION
Uncordoning the node when IgnoreDrainFailures is set will result in the node being uncordoned then immediately terminated since the drain failure is then ignored and termination continues anyway. Therefore it would be best not to uncordon it in this situation when the flag is set.