### PR TITLE
Abort on strategy failure instead of continuing

### DIFF
--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -2704,30 +2704,12 @@ func TestDrainNodeTerminateTerminatesWhenIgnoreDrainFailuresSet(t *testing.T) {
 		ScriptRunner: NewScriptRunner(log2.NullLogger{}),
 	}
 
-	ch := make(chan error, 1)
-	rcRollingUpgrade.DrainTerminate(ruObj, mockNode, mockNode, ch)
-
-	select {
-	case err, ok := <-ch:
-		fmt.Println(err)
-		g.Expect(ok).To(gomega.BeFalse()) // don't expect errors.
-	default:
-
-		// done.
-	}
+	err := rcRollingUpgrade.DrainTerminate(ruObj, mockNode, mockNode)
+	g.Expect(err).To(gomega.BeNil()) // don't expect errors.
 
 	// nodeName is empty when node isn't part of the cluster. It must skip drain and terminate.
-	ch = make(chan error, 1)
-	rcRollingUpgrade.DrainTerminate(ruObj, "", mockNode, ch)
-
-	select {
-	case err, ok := <-ch:
-		fmt.Println(err)
-		g.Expect(ok).To(gomega.BeFalse()) //don't expect errors.
-	default:
-
-		// done.
-	}
+	err = rcRollingUpgrade.DrainTerminate(ruObj, "", mockNode)
+	g.Expect(err).To(gomega.BeNil()) // don't expect errors.
 
 }
 

--- a/controllers/script_runner.go
+++ b/controllers/script_runner.go
@@ -141,7 +141,7 @@ func (r *ScriptRunner) PostWait(instanceID string, nodeName string, ruObj *upgra
 			result := errors.Wrap(err, msg)
 
 			if !ruObj.Spec.IgnoreDrainFailures {
-				r.info(ruObj, "Uncordoning the node %s since it failed to run postDrainWait Script", "nodeName", nodeName)
+				r.info(ruObj, "Uncordoning the node since it failed to run postDrainWait Script", "nodeName", nodeName)
 				_, err = r.uncordonNode(nodeName, ruObj)
 				if err != nil {
 					r.error(ruObj, err, "Failed to uncordon", "nodeName", nodeName)
@@ -163,7 +163,7 @@ func (r *ScriptRunner) PostDrain(instanceID string, nodeName string, ruObj *upgr
 			result := errors.Wrap(err, msg)
 
 			if !ruObj.Spec.IgnoreDrainFailures {
-				r.info(ruObj, "Uncordoning the node %s since it failed to run postDrain Script", "nodeName", nodeName)
+				r.info(ruObj, "Uncordoning the node since it failed to run postDrain Script", "nodeName", nodeName)
 				_, err = r.uncordonNode(nodeName, ruObj)
 				if err != nil {
 					r.error(ruObj, err, "Failed to uncordon", "nodeName", nodeName)


### PR DESCRIPTION
Abort on strategy failure instead of continuing.

Previously, when a failure occurred, namely such as when the postDrain helper script fails (#140), the error was sent to the error channel and returned to UpdateInstance (ie in the case of DrainAndTerminate - the node was only drained), however UpdateInstance did nothing to check this error and continued to WaitForTermination, etc.

I could not see why the error channel was passed through rather than directly returning an error so I changed it to do that, allowing UpdateInstance to abort early if it detects an error and pass the error back through the error channel as previously.

## Testing Done

Manually tested this branch on our sandbox cluster and performed two rolling upgrades with a `/bin/false` call in the postDrain script, one with `ignoreDrainFailure: true` which successfully passed without any reported error, and a second which errored out.

```
upgrade-manager-76f8f8c6d8-jhmvv rolling-upgrade-controller {"level":"error","ts":1606769967.175032,"logger":"controllers.RollingUpgrade","msg":"Failed to run postDrain script: ","rollingupgrade":"rollingupgrade-api-us-west-2c","error":"exit status 127","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128\ngithub.com/keikoproj/upgrade-manager/controllers.(*ScriptRunner).error\n\t/workspace/controllers/script_runner.go:101\ngithub.com/keikoproj/upgrade-manager/controllers.(*ScriptRunner).PostDrain\n\t/workspace/controllers/script_runner.go:159\ngithub.com/keikoproj/upgrade-manager/controllers.(*RollingUpgradeReconciler).postDrainHelper\n\t/workspace/controllers/rollingupgrade_controller.go:158\ngithub.com/keikoproj/upgrade-manager/controllers.(*RollingUpgradeReconciler).DrainNode\n\t/workspace/controllers/rollingupgrade_controller.go:212\ngithub.com/keikoproj/upgrade-manager/controllers.(*RollingUpgradeReconciler).DrainTerminate\n\t/workspace/controllers/rollingupgrade_controller.go:967\ngithub.com/keikoproj/upgrade-manager/controllers.(*RollingUpgradeReconciler).UpdateInstanceEager\n\t/workspace/controllers/rollingupgrade_controller.go:957\ngithub.com/keikoproj/upgrade-manager/controllers.(*RollingUpgradeReconciler).UpdateInstance\n\t/workspace/controllers/rollingupgrade_controller.go:1031"}
upgrade-manager-76f8f8c6d8-jhmvv rolling-upgrade-controller {"level":"info","ts":1606769967.1750689,"logger":"controllers.RollingUpgrade","msg":"Uncordoning the node %s since it failed to run postDrain Script","rollingupgrade":"rollingupgrade-api-us-west-2c","nodeName":"ip-172-30-228-52.us-west-2.compute.internal"}
upgrade-manager-76f8f8c6d8-jhmvv rolling-upgrade-controller {"level":"info","ts":1606769967.1750846,"logger":"controllers.RollingUpgrade","msg":"Running script","rollingupgrade":"rollingupgrade-api-us-west-2c","script":"/usr/local/bin/kubectl uncordon ip-172-30-228-52.us-west-2.compute.internal"}
upgrade-manager-76f8f8c6d8-jhmvv rolling-upgrade-controller {"level":"info","ts":1606769967.8605819,"logger":"controllers.RollingUpgrade","msg":"Script finished","rollingupgrade":"rollingupgrade-api-us-west-2c","output":"node/ip-172-30-228-52.us-west-2.compute.internal uncordoned\n"}
upgrade-manager-76f8f8c6d8-jhmvv rolling-upgrade-controller {"level":"error","ts":1606769967.8669488,"logger":"controllers.RollingUpgrade","msg":"Failed to runRestack","rollingupgrade":"rollingupgrade-api-us-west-2c","error":"Error updating instances, ErrorCount: 1, Errors: [Failed to run postDrain script: : exit status 127]","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128\ngithub.com/keikoproj/upgrade-manager/controllers.(*RollingUpgradeReconciler).error\n\t/workspace/controllers/rollingupgrade_controller.go:1139\ngithub.com/keikoproj/upgrade-manager/controllers.(*RollingUpgradeReconciler).Process\n\t/workspace/controllers/rollingupgrade_controller.go:662"}
``` 