### PR TITLE
Template version comparison fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ var (
 var (
 	CacheDefaultTTL                     = time.Second * 0
 	DescribeAutoScalingGroupsTTL        = 60 * time.Second
+	DescribeLaunchTemplatesTTL          = 60 * time.Second
 	CacheMaxItems                int64  = 5000
 	CacheItemsToPrune            uint32 = 500
 )
@@ -133,6 +134,7 @@ func main() {
 	cacheCfg := cache.NewConfig(CacheDefaultTTL, CacheMaxItems, CacheItemsToPrune)
 	cache.AddCaching(sess, cacheCfg)
 	cacheCfg.SetCacheTTL("autoscaling", "DescribeAutoScalingGroups", DescribeAutoScalingGroupsTTL)
+	cacheCfg.SetCacheTTL("ec2", "DescribeLaunchTemplates", DescribeLaunchTemplatesTTL)
 	sess.Handlers.Complete.PushFront(func(r *request.Request) {
 		ctx := r.HTTPRequest.Context()
 		log.Debugf("cache hit => %v, service => %s.%s",


### PR DESCRIPTION
Fixes #153 

This adds discovery for launch templates and fixes the launch template version comparison.

Before:
```
launch template version differs	{"rollingupgrade": "rolling-upgrade-nodes-20201207212022-1", "instanceVersion": "1", "templateVersion": "$Latest"}
```

After:
```
launch template version differs	{"rollingupgrade": "rolling-upgrade-nodes-20201207212022-2", "instanceVersion": "1", "templateVersion": "2"}
```
Signed-off-by: Eytan Avisror <Eytan_Avisror@hotmail.com>