### PR TITLE
Move constants to types so that they can be reused

### DIFF
--- a/api/v1alpha1/rollingupgrade_types.go
+++ b/api/v1alpha1/rollingupgrade_types.go
@@ -74,6 +74,15 @@ type RollingUpgradeStatus struct {
 	Conditions []RollingUpgradeCondition `json:"conditions,omitempty"`
 }
 
+const (
+	// StatusRunning marks the CR to be running.
+	StatusRunning = "running"
+	// StatusComplete marks the CR as completed.
+	StatusComplete = "completed"
+	// StatusError marks the CR as errored out.
+	StatusError = "error"
+)
+
 // RollingUpgradeCondition describes the state of the RollingUpgrade
 type RollingUpgradeCondition struct {
 	Type   UpgradeConditionType   `json:"type,omitempty"`

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -68,7 +68,7 @@ func TestErrorStatusMarkJanitor(t *testing.T) {
 
 	ctx := context.TODO()
 	rcRollingUpgrade.inProcessASGs.Store(someAsg, "processing")
-	rcRollingUpgrade.finishExecution(StatusError, 3, &ctx, instance)
+	rcRollingUpgrade.finishExecution(upgrademgrv1alpha1.StatusError, 3, &ctx, instance)
 	g.Expect(instance.ObjectMeta.Annotations[JanitorAnnotation]).To(gomega.Equal(ClearErrorFrequency))
 	_, exists := rcRollingUpgrade.inProcessASGs.Load(someAsg)
 	g.Expect(exists).To(gomega.BeFalse())
@@ -77,7 +77,7 @@ func TestErrorStatusMarkJanitor(t *testing.T) {
 func TestMarkObjForCleanupCompleted(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
-	ruObj.Status.CurrentStatus = StatusComplete
+	ruObj.Status.CurrentStatus = upgrademgrv1alpha1.StatusComplete
 
 	g.Expect(ruObj.ObjectMeta.Annotations).To(gomega.BeNil())
 	MarkObjForCleanup(ruObj)
@@ -87,7 +87,7 @@ func TestMarkObjForCleanupCompleted(t *testing.T) {
 func TestMarkObjForCleanupError(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
-	ruObj.Status.CurrentStatus = StatusError
+	ruObj.Status.CurrentStatus = upgrademgrv1alpha1.StatusError
 
 	g.Expect(ruObj.ObjectMeta.Annotations).To(gomega.BeNil())
 	MarkObjForCleanup(ruObj)
@@ -937,9 +937,9 @@ func TestFinishExecutionCompleted(t *testing.T) {
 	ctx := context.TODO()
 	mockNodesProcessed := 3
 
-	rcRollingUpgrade.finishExecution(StatusComplete, mockNodesProcessed, &ctx, ruObj)
+	rcRollingUpgrade.finishExecution(upgrademgrv1alpha1.StatusComplete, mockNodesProcessed, &ctx, ruObj)
 
-	g.Expect(ruObj.Status.CurrentStatus).To(gomega.Equal(StatusComplete))
+	g.Expect(ruObj.Status.CurrentStatus).To(gomega.Equal(upgrademgrv1alpha1.StatusComplete))
 	g.Expect(ruObj.Status.NodesProcessed).To(gomega.Equal(mockNodesProcessed))
 	g.Expect(ruObj.Status.EndTime).To(gomega.Not(gomega.BeNil()))
 	g.Expect(ruObj.Status.TotalProcessingTime).To(gomega.Not(gomega.BeNil()))
@@ -972,9 +972,9 @@ func TestFinishExecutionError(t *testing.T) {
 	ctx := context.TODO()
 	mockNodesProcessed := 3
 
-	rcRollingUpgrade.finishExecution(StatusError, mockNodesProcessed, &ctx, ruObj)
+	rcRollingUpgrade.finishExecution(upgrademgrv1alpha1.StatusError, mockNodesProcessed, &ctx, ruObj)
 
-	g.Expect(ruObj.Status.CurrentStatus).To(gomega.Equal(StatusError))
+	g.Expect(ruObj.Status.CurrentStatus).To(gomega.Equal(upgrademgrv1alpha1.StatusError))
 	g.Expect(ruObj.Status.NodesProcessed).To(gomega.Equal(mockNodesProcessed))
 	g.Expect(ruObj.Status.EndTime).To(gomega.Not(gomega.BeNil()))
 	g.Expect(ruObj.Status.TotalProcessingTime).To(gomega.Not(gomega.BeNil()))


### PR DESCRIPTION
Can't reuse from current package because it tries to pull dependency on kubernetes api, so build fails with mismatched dependency versions.
Moving constants to types removes dependency and simplifies reuse  outside.

These constants are part of the public API - they describe status of the rollout, so should be easy to consume.