### PR TITLE
Use standard fmt.Errorf to format error message; unify error format

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 
 	upgrademgrv1alpha1 "github.com/keikoproj/upgrade-manager/api/v1alpha1"
@@ -82,7 +81,7 @@ func getInstanceStateInASG(group *autoscaling.Group, instanceID string) (string,
 			return aws.StringValue(instance.LifecycleState), nil
 		}
 	}
-	return "", errors.Errorf("could not get instance group state, instance %v not found", instanceID)
+	return "", fmt.Errorf("could not get instance group state, instance %s not found", instanceID)
 }
 
 func isInServiceLifecycleState(state string) bool {

--- a/controllers/script_runner.go
+++ b/controllers/script_runner.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"github.com/go-logr/logr"
 	upgrademgrv1alpha1 "github.com/keikoproj/upgrade-manager/api/v1alpha1"
-	"github.com/pkg/errors"
 	"os"
 	"os/exec"
 	"strings"
@@ -112,7 +111,7 @@ func (r *ScriptRunner) PostTerminate(instanceID string, nodeName string, ruObj *
 			}
 			msg := "Failed to run postTerminate script"
 			r.error(ruObj, err, msg, "instanceID", instanceID)
-			return errors.Wrap(err, msg)
+			return fmt.Errorf("%s: %s: %w", ruObj.NamespacedName(), msg, err)
 		}
 	}
 	return nil
@@ -126,7 +125,7 @@ func (r *ScriptRunner) PreDrain(instanceID string, nodeName string, ruObj *upgra
 		if err != nil {
 			msg := "Failed to run preDrain script"
 			r.error(ruObj, err, msg)
-			return errors.Wrap(err, msg)
+			return fmt.Errorf("%s: %s: %w", ruObj.NamespacedName(), msg, err)
 		}
 	}
 	return nil
@@ -138,7 +137,7 @@ func (r *ScriptRunner) PostWait(instanceID string, nodeName string, ruObj *upgra
 		if err != nil {
 			msg := "Failed to run postDrainWait script: " + err.Error()
 			r.error(ruObj, err, msg)
-			result := errors.Wrap(err, msg)
+			result := fmt.Errorf("%s: %s: %w", ruObj.NamespacedName(), msg, err)
 
 			if !ruObj.Spec.IgnoreDrainFailures {
 				r.info(ruObj, "Uncordoning the node since it failed to run postDrainWait Script", "nodeName", nodeName)
@@ -160,7 +159,7 @@ func (r *ScriptRunner) PostDrain(instanceID string, nodeName string, ruObj *upgr
 		if err != nil {
 			msg := "Failed to run postDrain script: "
 			r.error(ruObj, err, msg)
-			result := errors.Wrap(err, msg)
+			result := fmt.Errorf("%s: %s: %w", ruObj.NamespacedName(), msg, err)
 
 			if !ruObj.Spec.IgnoreDrainFailures {
 				r.info(ruObj, "Uncordoning the node since it failed to run postDrain Script", "nodeName", nodeName)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/keikoproj/kubedog v0.0.1
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.4
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0
 	go.uber.org/zap v1.16.0
 	golang.org/x/net v0.0.0-20201216054612-986b41b23924

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"time"
 
@@ -29,7 +30,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/go-logr/logr"
 	"github.com/keikoproj/aws-sdk-go-cache/cache"
-	"github.com/pkg/errors"
 	uberzap "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -198,7 +198,7 @@ func deriveRegion() (string, error) {
 	c := ec2metadata.New(sess)
 	region, err := c.Region()
 	if err != nil {
-		return "", errors.Wrapf(err, "cannot reach ec2metadata, if running locally export AWS_REGION")
+		return "", fmt.Errorf("cannot reach ec2metadata, if running locally export AWS_REGION: %w", err)
 	}
 	return region, nil
 }


### PR DESCRIPTION
* Unify error messages.
* Use standard `fmt.Errorf` which support error wrapping.
* Remove dependency on `github.com/pkg/errors`.
* Make tests less fragile.