### PR TITLE
Bump golang and busybox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15.3 as builder
+FROM golang:1.15.6 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -23,7 +23,7 @@ RUN curl -L https://storage.googleapis.com/kubernetes-release/release/v1.14.10/b
 RUN chmod +x /usr/local/bin/kubectl
 
 # Add busybox
-FROM busybox:1.31 as shelladder
+FROM busybox:1.32.0 as shelladder
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
Bump golang to 1.15.6 to include latest security fixes.
Bump busybox to latest version.