### PR TITLE
show when test could not create config

### DIFF
--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -46,7 +46,11 @@ func TestMain(m *testing.M) {
 		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
 	}
 
-	cfg, _ = testEnv.Start()
+	var err error
+	cfg, err = testEnv.Start()
+	if err != nil {
+		panic(err)
+	}
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
before:
```
--- FAIL: TestRunRestackWithNodesLessThanMaxUnavailable (0.00s)
    rollingupgrade_controller_test.go:2486:
        Unexpected error:
            <*errors.errorString | 0xc00031ae10>: {
                s: "must specify Config",
            }
            must specify Config
        occurred
```

after:
```
go test ./controllers/... -run TestRunRestackWithNodesLessThanMaxUnavailable
panic: failed to start the controlplane. retried 5 times: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory
```

/cc @uthark 