### PR TITLE
Cache the ASG before nodes are rotated in a loop

### DIFF
--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -499,6 +499,10 @@ func (r *RollingUpgradeReconciler) getInProgressInstances(instances []*autoscali
 // runRestack performs rollout of new nodes.
 // returns number of processed instances and optional error.
 func (r *RollingUpgradeReconciler) runRestack(ctx *context.Context, ruObj *upgrademgrv1alpha1.RollingUpgrade) (int, error) {
+	err := r.populateAsg(ruObj)
+	if err != nil {
+		return 0, fmt.Errorf("%s: Unable to populate the ASG object: %w", ruObj.NamespacedName(), err)
+	}
 
 	asg, err := r.GetAutoScalingGroup(ruObj.NamespacedName())
 	if err != nil {

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -1138,28 +1138,6 @@ func TestRunRestackSameLaunchConfig(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 }
 
-func TestRunRestackRollingUpgradeNotInMap(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-
-	strategy := upgrademgrv1alpha1.UpdateStrategy{Mode: upgrademgrv1alpha1.UpdateStrategyModeLazy}
-	ruObj := &upgrademgrv1alpha1.RollingUpgrade{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
-		Spec: upgrademgrv1alpha1.RollingUpgradeSpec{Strategy: strategy},
-	}
-	rcRollingUpgrade := &RollingUpgradeReconciler{
-		Log:          log2.NullLogger{},
-		ClusterState: NewClusterState(),
-		ASGClient:    MockAutoscalingGroup{},
-		EC2Client:    MockEC2{},
-	}
-	ctx := context.TODO()
-
-	g.Expect(rcRollingUpgrade.ruObjNameToASG.Load(ruObj.NamespacedName())).To(gomega.BeNil())
-	int, err := rcRollingUpgrade.runRestack(&ctx, ruObj)
-	g.Expect(int).To(gomega.Equal(0))
-	g.Expect(err).To(gomega.Not(gomega.BeNil()))
-	g.Expect(err.Error()).To(gomega.HavePrefix("Unable to load ASG with name: foo"))
-}
-
 func TestRunRestackRollingUpgradeNodeNameNotFound(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 


### PR DESCRIPTION
- [x] Manual testing
- [x] Edge cases




There is a bug in the node rotation in upgrade-manager-v1 that will fail all the rollup CRs that have `StandBy/in-progress` instances

In the current implementation of upgrade-manager-v1, the node rotation mainly happens [in this loop](https://github.com/keikoproj/upgrade-manager/blob/dc2d58bcea4a6dc4202d2559111ef3a1516c46f5/controllers/rollingupgrade_controller.go#L532):

```
asg = getASG() // just loads the ASG and doesn't get the most frequent changes.
totalNodes = asg.Instances
for processedInstances < totalNodes {
    ...
    if thereAreAnyInProgressInstances{
        instances = selectInProgressInstances()
    } else {
        instances = selectInServiceInstances()
    }
rotateInstances(instances)
processedInstances += len(instances)
}
```

The final line **processedInstances += len(instances)** accounts not just the `InService` instances but also the `StandBy/ in-progress` instances.

Let's say, the ASG had 3 `InService` instances and one instance in `StandBy/in-progress`. So, we had 4 instances in total.
But the ASG was cached previously and had a count of 3 in `asgSize`, hence we skipped one instance because of which the launch config validation failed.


`2021-04-05T12:13:22.619Z	INFO	controllers.RollingUpgrade	Nodes in ASG that *might* need to be updated	{"rollingupgrade": "addon-upgrademgr-ns/iks-arktika-bdd-nightly-usw2-system-ng-nodelaunchconfig-qoq8zwub09zx", "asgName": "iks-arktika-bdd-nightly-usw2-system-ng-NodeGroup-1WVN49BGRKUMU", "asgSize": 3}`

In sum, the rollup CR will mostly fail whenever the upgrade-manager picks up a `StandBy/ in-progress` instance.  


**Quick fix: Cache the ASG just before we start the rotation.** 
```
asg = populateASG() // refresh AWS cache
totalNodes = asg.Instances
for processedInstances < totalNodes {
    ...
    if thereAreAnyInProgressInstances{
        instances = selectInProgressInstances()
    } else {
        instances = selectInServiceInstances()
    }
rotateInstances(instances)
processedInstances += len(instances)
}
```


PS: This is a bad design and costly as we are doing yet another AWS caching. This will be addressed in the upgrade-manager-v2 as we will cache only once at the beginning of the reconcile.