### PR TITLE
LastNodeTerminationTime & LastNodeDrainTime not set in v0.19

### DIFF
--- a/api/v1alpha1/rollingupgrade_types.go
+++ b/api/v1alpha1/rollingupgrade_types.go
@@ -75,8 +75,8 @@ type RollingUpgradeStatus struct {
 	TotalNodes          int    `json:"totalNodes,omitempty"`
 
 	Conditions              []RollingUpgradeCondition `json:"conditions,omitempty"`
-	LastNodeTerminationTime metav1.Time               `json:"lastTerminationTime,omitempty"`
-	LastNodeDrainTime       metav1.Time               `json:"lastDrainTime,omitempty"`
+	LastNodeTerminationTime *metav1.Time              `json:"lastTerminationTime,omitempty"`
+	LastNodeDrainTime       *metav1.Time              `json:"lastDrainTime,omitempty"`
 
 	Statistics     []*RollingUpgradeStatistics `json:"statistics,omitempty"`
 	LastBatchNodes []string                    `json:"lastBatchNodes,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -248,8 +248,14 @@ func (in *RollingUpgradeStatus) DeepCopyInto(out *RollingUpgradeStatus) {
 		*out = make([]RollingUpgradeCondition, len(*in))
 		copy(*out, *in)
 	}
-	in.LastNodeTerminationTime.DeepCopyInto(&out.LastNodeTerminationTime)
-	in.LastNodeDrainTime.DeepCopyInto(&out.LastNodeDrainTime)
+	if in.LastNodeTerminationTime != nil {
+		in, out := &in.LastNodeTerminationTime, &out.LastNodeTerminationTime
+		*out = (*in).DeepCopy()
+	}
+	if in.LastNodeDrainTime != nil {
+		in, out := &in.LastNodeDrainTime, &out.LastNodeDrainTime
+		*out = (*in).DeepCopy()
+	}
 	if in.Statistics != nil {
 		in, out := &in.Statistics, &out.Statistics
 		*out = make([]*RollingUpgradeStatistics, len(*in))

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -1048,7 +1048,7 @@ func (r *RollingUpgradeReconciler) DrainTerminate(
 		if err := r.DrainNode(ruObj, nodeName, targetInstanceID, ruObj.Spec.Strategy.DrainTimeout, nodeSteps, inProcessingNodes, mutex); err != nil {
 			return err
 		}
-		ruObj.Status.LastNodeDrainTime = metav1.Time{Time: time.Now()}
+		ruObj.Status.LastNodeDrainTime = &metav1.Time{Time: time.Now()}
 	}
 
 	// Terminate instance.
@@ -1057,7 +1057,7 @@ func (r *RollingUpgradeReconciler) DrainTerminate(
 		return err
 	}
 
-	ruObj.Status.LastNodeTerminationTime = metav1.Time{Time: time.Now()}
+	ruObj.Status.LastNodeTerminationTime = &metav1.Time{Time: time.Now()}
 	ruObj.Status.NodeStep(inProcessingNodes, nodeSteps, ruObj.Spec.AsgName, nodeName, v1alpha1.NodeRotationCompleted, mutex)
 
 	return nil

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -224,6 +224,7 @@ func (r *RollingUpgradeReconciler) DrainNode(ruObj *upgrademgrv1alpha1.RollingUp
 	}
 
 	ruObj.Status.NodeStep(inProcessingNodes, nodeSteps, ruObj.Spec.AsgName, nodeName, v1alpha1.NodeRotationPostdrainScript, mutex)
+
 	return r.postDrainHelper(instanceID, nodeName, ruObj, nodeSteps, inProcessingNodes, mutex)
 }
 

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -224,7 +224,6 @@ func (r *RollingUpgradeReconciler) DrainNode(ruObj *upgrademgrv1alpha1.RollingUp
 	}
 
 	ruObj.Status.NodeStep(inProcessingNodes, nodeSteps, ruObj.Spec.AsgName, nodeName, v1alpha1.NodeRotationPostdrainScript, mutex)
-
 	return r.postDrainHelper(instanceID, nodeName, ruObj, nodeSteps, inProcessingNodes, mutex)
 }
 
@@ -1049,6 +1048,7 @@ func (r *RollingUpgradeReconciler) DrainTerminate(
 			return err
 		}
 	}
+	ruObj.Status.LastNodeDrainTime = metav1.Time{Time: time.Now()}
 
 	// Terminate instance.
 	err := r.TerminateNode(ruObj, targetInstanceID, nodeName, nodeSteps, inProcessingNodes, mutex)
@@ -1056,6 +1056,7 @@ func (r *RollingUpgradeReconciler) DrainTerminate(
 		return err
 	}
 
+	ruObj.Status.LastNodeTerminationTime = metav1.Time{Time: time.Now()}
 	ruObj.Status.NodeStep(inProcessingNodes, nodeSteps, ruObj.Spec.AsgName, nodeName, v1alpha1.NodeRotationCompleted, mutex)
 
 	return nil

--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -1048,8 +1048,8 @@ func (r *RollingUpgradeReconciler) DrainTerminate(
 		if err := r.DrainNode(ruObj, nodeName, targetInstanceID, ruObj.Spec.Strategy.DrainTimeout, nodeSteps, inProcessingNodes, mutex); err != nil {
 			return err
 		}
+		ruObj.Status.LastNodeDrainTime = metav1.Time{Time: time.Now()}
 	}
-	ruObj.Status.LastNodeDrainTime = metav1.Time{Time: time.Now()}
 
 	// Terminate instance.
 	err := r.TerminateNode(ruObj, targetInstanceID, nodeName, nodeSteps, inProcessingNodes, mutex)

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -1535,6 +1535,8 @@ func TestUpdateInstances(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(ruObj.Status.Statistics).ShouldNot(gomega.BeEmpty())
 	g.Expect(ruObj.Status.LastBatchNodes).ShouldNot(gomega.BeEmpty())
+	g.Expect(ruObj.Status.LastNodeDrainTime).ShouldNot(gomega.BeEmpty())
+	g.Expect(ruObj.Status.LastNodeTerminationTime).ShouldNot(gomega.BeEmpty())
 }
 
 func TestUpdateInstancesError(t *testing.T) {
@@ -2772,6 +2774,8 @@ func TestDrainNodeTerminateTerminatesWhenIgnoreDrainFailuresSet(t *testing.T) {
 
 	err := rcRollingUpgrade.DrainTerminate(ruObj, mockNode, mockNode, nodeSteps, inProcessingNodes, mutex)
 	g.Expect(err).To(gomega.BeNil()) // don't expect errors.
+	g.Expect(ruObj.Status.LastNodeDrainTime).ShouldNot(gomega.BeEmpty())
+	g.Expect(ruObj.Status.LastNodeTerminationTime).ShouldNot(gomega.BeEmpty())
 
 	// nodeName is empty when node isn't part of the cluster. It must skip drain and terminate.
 	err = rcRollingUpgrade.DrainTerminate(ruObj, "", mockNode, nodeSteps, inProcessingNodes, mutex)

--- a/controllers/rollingupgrade_controller_test.go
+++ b/controllers/rollingupgrade_controller_test.go
@@ -1535,8 +1535,8 @@ func TestUpdateInstances(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(ruObj.Status.Statistics).ShouldNot(gomega.BeEmpty())
 	g.Expect(ruObj.Status.LastBatchNodes).ShouldNot(gomega.BeEmpty())
-	g.Expect(ruObj.Status.LastNodeDrainTime).ShouldNot(gomega.BeEmpty())
-	g.Expect(ruObj.Status.LastNodeTerminationTime).ShouldNot(gomega.BeEmpty())
+	g.Expect(ruObj.Status.LastNodeDrainTime).ShouldNot(gomega.BeNil())
+	g.Expect(ruObj.Status.LastNodeTerminationTime).ShouldNot(gomega.BeNil())
 }
 
 func TestUpdateInstancesError(t *testing.T) {
@@ -2774,8 +2774,8 @@ func TestDrainNodeTerminateTerminatesWhenIgnoreDrainFailuresSet(t *testing.T) {
 
 	err := rcRollingUpgrade.DrainTerminate(ruObj, mockNode, mockNode, nodeSteps, inProcessingNodes, mutex)
 	g.Expect(err).To(gomega.BeNil()) // don't expect errors.
-	g.Expect(ruObj.Status.LastNodeDrainTime).ShouldNot(gomega.BeEmpty())
-	g.Expect(ruObj.Status.LastNodeTerminationTime).ShouldNot(gomega.BeEmpty())
+	g.Expect(ruObj.Status.LastNodeDrainTime).ShouldNot(gomega.BeNil())
+	g.Expect(ruObj.Status.LastNodeTerminationTime).ShouldNot(gomega.BeNil())
 
 	// nodeName is empty when node isn't part of the cluster. It must skip drain and terminate.
 	err = rcRollingUpgrade.DrainTerminate(ruObj, "", mockNode, nodeSteps, inProcessingNodes, mutex)


### PR DESCRIPTION
LastNodeTerminationTime & LastNodeDrainTime was not set in the v0.19 of upgrade-manager v1.
This fixes the issue.