### PR TITLE
Revert "Fix metrics collecting issue"

### DIFF
--- a/api/v1alpha1/rollingupgrade_types.go
+++ b/api/v1alpha1/rollingupgrade_types.go
@@ -54,8 +54,8 @@ type RollingUpgradeStatus struct {
 	LastNodeTerminationTime *metav1.Time              `json:"lastTerminationTime,omitempty"`
 	LastNodeDrainTime       *metav1.Time              `json:"lastDrainTime,omitempty"`
 
-	Statistics     []*RollingUpgradeStatistics  `json:"statistics,omitempty"`
-	LastBatchNodes map[string]*NodeInProcessing `json:"lastBatchNodes,omitempty"`
+	Statistics     []*RollingUpgradeStatistics `json:"statistics,omitempty"`
+	LastBatchNodes []string                    `json:"lastBatchNodes,omitempty"`
 }
 
 // RollingUpgrade Statistics, includes summary(sum/count) from each step

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -10,7 +10,11 @@ import (
 
 // Update last batch nodes
 func (s *RollingUpgradeContext) UpdateLastBatchNodes(batchNodes map[string]*v1alpha1.NodeInProcessing) {
-	s.RollingUpgrade.Status.LastBatchNodes = batchNodes
+	keys := make([]string, 0, len(batchNodes))
+	for k := range batchNodes {
+		keys = append(keys, k)
+	}
+	s.RollingUpgrade.Status.LastBatchNodes = keys
 }
 
 // Update Node Statistics

--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -131,10 +131,7 @@ func (r *RollingUpgradeContext) ReplaceNodeBatch(batch []*autoscaling.Instance) 
 	//A map to retain the steps for multiple nodes
 	nodeSteps := make(map[string][]v1alpha1.NodeStepDuration)
 
-	inProcessingNodes := r.RollingUpgrade.Status.LastBatchNodes
-	if inProcessingNodes == nil {
-		inProcessingNodes = make(map[string]*v1alpha1.NodeInProcessing)
-	}
+	inProcessingNodes := make(map[string]*v1alpha1.NodeInProcessing)
 
 	switch mode {
 	case v1alpha1.UpdateStrategyModeEager:


### PR DESCRIPTION
Reverts keikoproj/upgrade-manager#249

PR #249 breaks the build. Hence I am reverting the PR.

```
intuitdep4170e:upgrade-manager sbadiger$ make run
/Users/sbadiger/Work/Keiko/upgrade-manager/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
/Users/sbadiger/Work/Keiko/upgrade-manager/bin/controller-gen "crd:trivialVersions=true,preserveUnknownFields=false" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
go run ./main.go
2021-06-16T00:16:24.076-0700	INFO	main	starting watch in all namespaces
I0616 00:16:25.839004   22286 request.go:655] Throttling request took 1.003732767s, request: GET:https://eksapi-sbadiger-fe098ef1c6757396.elb.us-west-2.amazonaws.com/apis/networking.k8s.io/v1?timeout=32s
2021-06-16T00:16:34.574-0700	INFO	controller-runtime.metrics	metrics server is starting to listen	{"addr": ":8080"}
2021-06-16T00:16:34.584-0700	INFO	controllers.RollingUpgrade	setting max parallel reconcile	{"value": 10}
2021-06-16T00:16:34.584-0700	INFO	main	registering prometheus
2021-06-16T00:16:34.584-0700	INFO	main	starting manager
2021-06-16T00:16:34.585-0700	INFO	controller-runtime.manager	starting metrics server	{"path": "/metrics"}
2021-06-16T00:16:34.585-0700	INFO	controller-runtime.manager.controller.rollingupgrade	Starting EventSource	{"reconciler group": "upgrademgr.keikoproj.io", "reconciler kind": "RollingUpgrade", "source": "kind source: /, Kind="}
E0616 00:16:34.907968   22286 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.4/tools/cache/reflector.go:167: Failed to watch *v1alpha1.RollingUpgrade: failed to list *v1alpha1.RollingUpgrade: v1alpha1.RollingUpgradeList.Items: []v1alpha1.RollingUpgrade: v1alpha1.RollingUpgrade.Status: v1alpha1.RollingUpgradeStatus.LastBatchNodes: ReadMapCB: expect { or n, but found [, error found in #10 byte of ...|chNodes":["ip-10-197|..., bigger context ...|s":{"currentStatus":"completed","lastBatchNodes":["ip-10-197-115-39.us-west-2.compute.internal"],"la|...
E0616 00:16:36.606423   22286 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.4/tools/cache/reflector.go:167: Failed to watch *v1alpha1.RollingUpgrade: failed to list *v1alpha1.RollingUpgrade: v1alpha1.RollingUpgradeList.Items: []v1alpha1.RollingUpgrade: v1alpha1.RollingUpgrade.Status: v1alpha1.RollingUpgradeStatus.LastBatchNodes: ReadMapCB: expect { or n, but found [, error found in #10 byte of ...|chNodes":["ip-10-197|..., bigger context ...|s":{"currentStatus":"completed","lastBatchNodes":["ip-10-197-115-39.us-west-2.compute.internal"],"la|...
E0616 00:16:39.531119   22286 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.4/tools/cache/reflector.go:167: Failed to watch *v1alpha1.RollingUpgrade: failed to list *v1alpha1.RollingUpgrade: v1alpha1.RollingUpgradeList.Items: []v1alpha1.RollingUpgrade: v1alpha1.RollingUpgrade.Status: v1alpha1.RollingUpgradeStatus.LastBatchNodes: ReadMapCB: expect { or n, but found [, error found in #10 byte of ...|chNodes":["ip-10-197|..., bigger context ...|s":{"currentStatus":"completed","lastBatchNodes":["ip-10-197-114-250.us-west-2.compute.internal"],"l|...
```