### PR TITLE
upgrade-manager-v2: expose totalProcessing time and other metrics

### DIFF
--- a/api/v1alpha1/rollingupgrade_types.go
+++ b/api/v1alpha1/rollingupgrade_types.go
@@ -304,6 +304,10 @@ func (r *RollingUpgrade) EndTime() string {
 	return r.Status.EndTime
 }
 
+func (r *RollingUpgrade) SetTotalProcessingTime(t string) {
+	r.Status.TotalProcessingTime = t
+}
+
 func (r *RollingUpgrade) SetTotalNodes(n int) {
 	r.Status.TotalNodes = n
 }

--- a/controllers/common/metrics.go
+++ b/controllers/common/metrics.go
@@ -33,6 +33,12 @@ var (
 			},
 		})
 
+	totalProcessingTime = make(map[string]prometheus.Summary)
+
+	totalNodesMetrics = make(map[string]prometheus.Gauge)
+
+	nodesProcessedMetrics = make(map[string]prometheus.Gauge)
+
 	stepSummaries = make(map[string]map[string]prometheus.Summary)
 
 	stepSumMutex = sync.Mutex{}
@@ -53,6 +59,69 @@ var (
 func InitMetrics() {
 	metrics.Registry.MustRegister(nodeRotationTotal)
 	metrics.Registry.MustRegister(CRStatus)
+}
+
+// observe total processing time
+func TotalProcessingTime(groupName string, duration time.Duration) {
+	var summary prometheus.Summary
+	if s, ok := totalProcessingTime[groupName]; !ok {
+		summary = prometheus.NewSummary(
+			prometheus.SummaryOpts{
+				Namespace:   metricNamespace,
+				Name:        "total_processing_time_seconds",
+				Help:        "Total processing time for all nodes in the group",
+				ConstLabels: prometheus.Labels{"group": groupName},
+			})
+		err := metrics.Registry.Register(summary)
+		if err != nil {
+			if reflect.TypeOf(err).String() == "prometheus.AlreadyRegisteredError" {
+				log.Warnf("summary was registered again, group: %s", groupName)
+			} else {
+				log.Errorf("register summary error, group: %s, %v", groupName, err)
+			}
+		}
+		stepSumMutex.Lock()
+		totalProcessingTime[groupName] = summary
+		stepSumMutex.Unlock()
+	} else {
+		summary = s
+	}
+	summary.Observe(duration.Seconds())
+}
+
+func addGaugeOrUpdate(gaugeMap map[string]prometheus.Gauge, groupName string, count int, metricName, help string) {
+	var gauge prometheus.Gauge
+	if c, ok := gaugeMap[groupName]; !ok {
+		gauge = prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   metricNamespace,
+				Name:        metricName,
+				Help:        help,
+				ConstLabels: prometheus.Labels{"group": groupName},
+			})
+		err := metrics.Registry.Register(gauge)
+		if err != nil {
+			if reflect.TypeOf(err).String() == "prometheus.AlreadyRegisteredError" {
+				log.Warnf("gauge was registered again, group: %s", groupName)
+			} else {
+				log.Errorf("register gauge error, group: %s, %v", groupName, err)
+			}
+		}
+		stepSumMutex.Lock()
+		gaugeMap[groupName] = gauge
+		stepSumMutex.Unlock()
+	} else {
+		gauge = c
+	}
+	gauge.Set(float64(count))
+}
+
+func SetTotalNodesMetric(groupName string, nodes int) {
+	addGaugeOrUpdate(totalNodesMetrics, groupName, nodes, "total_nodes", "Total nodes in the group")
+}
+
+func SetNodesProcessedMetric(groupName string, nodesProcessed int) {
+	addGaugeOrUpdate(nodesProcessedMetrics, groupName, nodesProcessed, "nodes_processed", "Nodes processed in the group")
 }
 
 // Add rolling update step duration when the step is completed

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -10,6 +10,7 @@ import (
 
 // Update last batch nodes
 func (s *RollingUpgradeContext) UpdateLastBatchNodes(batchNodes map[string]*v1alpha1.NodeInProcessing) {
+	s.RollingUpgrade.Status.NodeInProcessing = batchNodes
 	keys := make([]string, 0, len(batchNodes))
 	for k := range batchNodes {
 		keys = append(keys, k)

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -10,7 +10,6 @@ import (
 
 // Update last batch nodes
 func (s *RollingUpgradeContext) UpdateLastBatchNodes(batchNodes map[string]*v1alpha1.NodeInProcessing) {
-	s.RollingUpgrade.Status.NodeInProcessing = batchNodes
 	keys := make([]string, 0, len(batchNodes))
 	for k := range batchNodes {
 		keys = append(keys, k)

--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -554,13 +554,18 @@ func (r *RollingUpgradeContext) SetProgress(nodesProcessed int, totalNodes int) 
 	r.RollingUpgrade.SetTotalNodes(totalNodes)
 	r.RollingUpgrade.SetNodesProcessed(nodesProcessed)
 	r.RollingUpgrade.SetCompletePercentage(completePercentage)
+
+	// expose total nodes and nodes processed to prometheus
+	common.SetTotalNodesMetric(r.RollingUpgrade.ScalingGroupName(), totalNodes)
+	common.SetNodesProcessedMetric(r.RollingUpgrade.ScalingGroupName(), nodesProcessed)
+
 }
 
 func (r *RollingUpgradeContext) endTimeUpdate() {
-	//set end time
+	// set end time
 	r.RollingUpgrade.SetEndTime(time.Now().Format(time.RFC3339))
 
-	//set total processing time
+	// set total processing time
 	startTime, err1 := time.Parse(time.RFC3339, r.RollingUpgrade.StartTime())
 	endTime, err2 := time.Parse(time.RFC3339, r.RollingUpgrade.EndTime())
 	if err1 != nil || err2 != nil {
@@ -568,5 +573,8 @@ func (r *RollingUpgradeContext) endTimeUpdate() {
 	} else {
 		var totalProcessingTime = endTime.Sub(startTime)
 		r.RollingUpgrade.SetTotalProcessingTime(totalProcessingTime.String())
+
+		// expose total processing time to prometheus
+		common.TotalProcessingTime(r.RollingUpgrade.ScalingGroupName(), totalProcessingTime)
 	}
 }

--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -110,6 +110,7 @@ func (r *RollingUpgradeContext) RotateNodes() error {
 	if !r.IsScalingGroupDrifted() {
 		r.RollingUpgrade.SetCurrentStatus(v1alpha1.StatusComplete)
 		common.SetMetricRollupCompleted(r.RollingUpgrade.Name)
+		r.endTimeUpdate()
 		return nil
 	}
 
@@ -553,4 +554,19 @@ func (r *RollingUpgradeContext) SetProgress(nodesProcessed int, totalNodes int) 
 	r.RollingUpgrade.SetTotalNodes(totalNodes)
 	r.RollingUpgrade.SetNodesProcessed(nodesProcessed)
 	r.RollingUpgrade.SetCompletePercentage(completePercentage)
+}
+
+func (r *RollingUpgradeContext) endTimeUpdate() {
+	//set end time
+	r.RollingUpgrade.SetEndTime(time.Now().Format(time.RFC3339))
+
+	//set total processing time
+	startTime, err1 := time.Parse(time.RFC3339, r.RollingUpgrade.StartTime())
+	endTime, err2 := time.Parse(time.RFC3339, r.RollingUpgrade.EndTime())
+	if err1 != nil || err2 != nil {
+		r.Info("failed to calculate totalProcessingTime")
+	} else {
+		var totalProcessingTime = endTime.Sub(startTime)
+		r.RollingUpgrade.SetTotalProcessingTime(totalProcessingTime.String())
+	}
 }


### PR DESCRIPTION
Migrating https://github.com/keikoproj/upgrade-manager/pull/260 changes to upgrade-manager-v2
The idea is to expose totalProcessing, totalNodes, and nodesProcessed to Prometheus.