### PR TITLE
Carry the metrics status in RollingUpgrade CR

### DIFF
--- a/api/v1alpha1/rollingupgrade_types.go
+++ b/api/v1alpha1/rollingupgrade_types.go
@@ -168,6 +168,7 @@ const (
 	NodeRotationPostWait         RollingUpgradeStep = "post_wait"
 	NodeRotationTerminate        RollingUpgradeStep = "terminate"
 	NodeRotationPostTerminate    RollingUpgradeStep = "post_terminate"
+	NodeRotationTerminated       RollingUpgradeStep = "terminated"
 	NodeRotationCompleted        RollingUpgradeStep = "completed"
 )
 
@@ -180,6 +181,7 @@ var NodeRotationStepOrders = map[RollingUpgradeStep]int{
 	NodeRotationPostWait:         60,
 	NodeRotationTerminate:        70,
 	NodeRotationPostTerminate:    80,
+	NodeRotationTerminated:       90,
 	NodeRotationCompleted:        1000,
 }
 

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -8,6 +8,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Update metrics status UpdateMetricsStatus
+func (s *RollingUpgradeContext) UpdateMetricsStatus(batchNodes map[string]*v1alpha1.NodeInProcessing, nodeSteps map[string][]v1alpha1.NodeStepDuration) {
+	s.UpdateLastBatchNodes(batchNodes)
+	s.UpdateStatistics(nodeSteps)
+}
+
 // Update last batch nodes
 func (s *RollingUpgradeContext) UpdateLastBatchNodes(batchNodes map[string]*v1alpha1.NodeInProcessing) {
 	s.RollingUpgrade.Status.NodeInProcessing = batchNodes

--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -306,6 +306,7 @@ func (r *RollingUpgradeContext) ReplaceNodeBatch(batch []*autoscaling.Instance) 
 			if err := r.Auth.TerminateInstance(target); err != nil {
 				// terminate failures are retryable
 				r.Info("failed to terminate instance", "instance", instanceID, "message", err.Error(), "name", r.RollingUpgrade.NamespacedName())
+				r.UpdateMetricsStatus(inProcessingNodes, nodeSteps)
 				return true, nil
 			}
 			r.RollingUpgrade.SetLastNodeTerminationTime(&metav1.Time{Time: time.Now()})

--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -323,7 +323,7 @@ func (r *RollingUpgradeContext) ReplaceNodeBatch(batch []*autoscaling.Instance) 
 			terminatedTime := metav1.Time{
 				Time: metav1.Now().Add(time.Duration(r.RollingUpgrade.NodeIntervalSeconds()) * time.Second),
 			}
-			r.DoNodeStep(inProcessingNodes, nodeSteps, r.RollingUpgrade.Spec.AsgName, nodeName, v1alpha1.NodeRotationTerminated, terminatedTime)
+			r.NodeStep(inProcessingNodes, nodeSteps, r.RollingUpgrade.Spec.AsgName, nodeName, v1alpha1.NodeRotationTerminated)
 			r.DoNodeStep(inProcessingNodes, nodeSteps, r.RollingUpgrade.Spec.AsgName, nodeName, v1alpha1.NodeRotationCompleted, terminatedTime)
 		}
 

--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -319,7 +319,7 @@ func (r *RollingUpgradeContext) ReplaceNodeBatch(batch []*autoscaling.Instance) 
 				return false, err
 			}
 
-			//Predict terminating time
+			//Calculate the terminating time,
 			terminatedTime := metav1.Time{
 				Time: metav1.Now().Add(time.Duration(r.RollingUpgrade.NodeIntervalSeconds()) * time.Second),
 			}

--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -319,8 +319,12 @@ func (r *RollingUpgradeContext) ReplaceNodeBatch(batch []*autoscaling.Instance) 
 				return false, err
 			}
 
-			// Turns onto NodeRotationCompleted
-			r.NodeStep(inProcessingNodes, nodeSteps, r.RollingUpgrade.Spec.AsgName, nodeName, v1alpha1.NodeRotationCompleted)
+			//Predict terminating time
+			terminatedTime := metav1.Time{
+				Time: metav1.Now().Add(time.Duration(r.RollingUpgrade.NodeIntervalSeconds()) * time.Second),
+			}
+			r.DoNodeStep(inProcessingNodes, nodeSteps, r.RollingUpgrade.Spec.AsgName, nodeName, v1alpha1.NodeRotationTerminated, terminatedTime)
+			r.DoNodeStep(inProcessingNodes, nodeSteps, r.RollingUpgrade.Spec.AsgName, nodeName, v1alpha1.NodeRotationCompleted, terminatedTime)
 		}
 
 		r.UpdateMetricsStatus(inProcessingNodes, nodeSteps)


### PR DESCRIPTION
1. Carry the metrics status in RollingUpgrade CR
2. Add Terminating wait in terminated step