### PR TITLE
Add missing ec2 LaunchTemplate actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ If you already have an existing cluster created using kops, follow the instructi
     "Action": [
         "ec2:CreateTags",
         "ec2:DescribeInstances",
+        "ec2:DescribeLaunchTemplates",
+        "ec2:DescribeLaunchTemplateVersions",
         "autoscaling:EnterStandby",
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:TerminateInstanceInAutoScalingGroup"


### PR DESCRIPTION
They are required by https://github.com/keikoproj/instance-manager/blob/306c823e7c06f5087b6acc70a0f9df4da78dc51a/controllers/provisioners/eks/cloud.go#L108