### PR TITLE
fix: Flush EC2 service cache on new rollup 

### DIFF
--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -141,6 +141,7 @@ func (r *RollingUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if _, present := r.AdmissionMap.LoadOrStore(rollingUpgrade.NamespacedName(), scalingGroupName); !present {
 		r.Info("admitted new rolling upgrade", "scalingGroup", scalingGroupName, "update strategy", rollingUpgrade.Spec.Strategy, "name", rollingUpgrade.NamespacedName())
 		r.CacheConfig.FlushCache("autoscaling")
+		r.CacheConfig.FlushCache("ec2")
 	} else {
 		r.Info("operating on existing rolling upgrade", "scalingGroup", scalingGroupName, "update strategy", rollingUpgrade.Spec.Strategy, "name", rollingUpgrade.NamespacedName())
 	}


### PR DESCRIPTION
Signed-off-by: Eytan Avisror <Eytan_Avisror@intuit.com>

Fixes #309

This issue caused by stale cache in LaunchTemplate versions if multiple upgrades happen in succession:

https://github.com/keikoproj/upgrade-manager/blob/c593b0157de1e2910b4479f006bdfdb9b3de46d5/controllers/upgrade.go#L508-L510

In this case `r.Cloud.LaunchTemplates` template versions is stale, adding the flushing on new rollup admission should fix this problem.
