### PR TITLE
Release v1.0.5

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v1.0.5] - 2021-10-04
+8e0f67d Update rollingupgrade_controller.go (#322)
+9b1d11c add README (#320)
+167e10b EOL of upgrade-manager-v0 and make upgrade-manager-v1 the default. (#319)
+
 ## [v1.0.4] - 2021-10-04
 995b81b controller flags for ignoreDrainFailures and drainTimeout (#307)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.0.4
+VERSION=1.0.5
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: keikoproj/rolling-upgrade-controller:1.0.4
+      - image: keikoproj/rolling-upgrade-controller:1.0.5
         name: manager


### PR DESCRIPTION
Major changes in v1.0.5
- Merge upgrade-manager-v1 to the master branch.
- Fix launch template bug by flushing the cache on every reconcile. (ec2 object flush).
- Update readme and add flow chart.