### PR TITLE
Fix CI Github action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.45.2
+        version: v1.43.0
         args: --timeout 2m
 
     - name: Get kubebuilder

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.44.2
+        version: v1.45.1
         args: --timeout 2m
 
     - name: Get kubebuilder

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.43.0
+        version: v1.44.0
         args: --timeout 2m
 
     - name: Get kubebuilder

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,7 @@ on:
 
 jobs:
   build:
-    name: CI # Lint, Test, Codecov, Docker build & Push
-    if: github.repository == 'keikoproj/upgrade-manager'
+    name: CI # Lint, Test, Codecov, Docker build & Push 
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.45.1
+        version: v1.45.2
         args: --timeout 2m
 
     - name: Get kubebuilder

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.32
+        version: v1.45.2
         args: --timeout 2m
 
     - name: Get kubebuilder

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.44.0
+        version: v1.44.2
         args: --timeout 2m
 
     - name: Get kubebuilder

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
We had to update golangci-lint package to latest release -> 1.45.2 (because we started seeing lint package related errors)

However, 1.45.2 uses golang 1.18
And in golang-1.18 installing packages through `go get` is deprecated.

Hence, I have replaced `go-get` with `go-install`