### PR TITLE
fix minor bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vet:
 	go vet ./...
 
 # Generate code
-generate: clean controller-gen
+generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Build the docker image


### PR DESCRIPTION
- Complete percentage used to show negative values. Avoid setting progress when the values are below allowed values.
- Remove `clean` target from `generate` target.
- Fixes - https://github.com/keikoproj/upgrade-manager/issues/323