### PR TITLE
Fix multi-arch support and delete docker-build step from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,10 +49,6 @@ jobs:
         flags: unittests # optional
         name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)
-        
-    - name: Docker build
-      if: github.event_name == 'pull_request' || (github.repository != 'keikoproj/upgrade-manager' && github.event_name == 'push')
-      run: make docker-build
 
     - name: Set up Docker Buildx
       if: (github.event_name == 'push' || github.event_name == 'release') && github.repository == 'keikoproj/upgrade-manager'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,13 @@ jobs:
         name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)
 
+    - name: Set up QEMU
+      if: (github.event_name == 'push' || github.event_name == 'release') && github.repository == 'keikoproj/upgrade-manager'
+      id: qemu
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: all
+
     - name: Set up Docker Buildx
       if: (github.event_name == 'push' || github.event_name == 'release') && github.repository == 'keikoproj/upgrade-manager'
       id: buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM --platform=$BUILDPLATFORM golang:1.17 as builder
+ARG TARGETOS TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,7 +16,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -a -o manager main.go
 
 # Add busybox
 FROM busybox:1.32.1 as shelladder


### PR DESCRIPTION
Following changes included in the PR:
- There is no need to do a local docker-build step as we are already running a `make test` step.
- Update go version in the Dockerfile to 1.17
- Include additional variables TARGETOS, TARGETARCH
- Include QEMU step in CI
