### PR TITLE
Release v1.0.10

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v1.0.10] - 2024-04-01
+b48d119 consider in-progress instances for UniformAcrossAZ update strategy (#438)
+7511a22 Bump github.com/aws/aws-sdk-go from 1.48.4 to 1.48.16 (#419)
+
 ## [v1.0.9] - 2023-12-06
 c2fdb37 Early cordon (#405)
 1201813 Bump sigs.k8s.io/controller-runtime from 0.12.1 to 0.12.3 (#416)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.0.9
+VERSION=1.0.10
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: keikoproj/rolling-upgrade-controller:1.0.9
+      - image: keikoproj/rolling-upgrade-controller:1.0.10
         name: manager


### PR DESCRIPTION
## [v1.0.10] - 2024-04-01
b48d119 consider in-progress instances for UniformAcrossAZ update strategy (#438)
7511a22 Bump github.com/aws/aws-sdk-go from 1.48.4 to 1.48.16 (#419)