### PR TITLE
controllers: set Complete condition on terminal RollingUpgrade states

### DIFF
--- a/controllers/rollingupgrade_controller.go
+++ b/controllers/rollingupgrade_controller.go
@@ -226,6 +226,10 @@ func (r *RollingUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err := rollupCtx.RotateNodes(); err != nil {
 		rollingUpgrade.SetCurrentStatus(v1alpha1.StatusError)
 		rollingUpgrade.SetLabel(v1alpha1.LabelKeyRollingUpgradeCurrentStatus, v1alpha1.StatusError)
+		rollingUpgrade.Status.SetCondition(v1alpha1.RollingUpgradeCondition{
+			Type:   v1alpha1.UpgradeComplete,
+			Status: corev1.ConditionFalse,
+		})
 		common.SetMetricRollupFailed(rollingUpgrade.Name)
 
 		// try to uncordon all the cordoned nodes.

--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -90,6 +90,10 @@ func (r *RollingUpgradeContext) RotateNodes() error {
 		r.Info("failed to discover the cloud", "scalingGroup", r.RollingUpgrade.ScalingGroupName(), "name", r.RollingUpgrade.NamespacedName())
 		r.RollingUpgrade.SetCurrentStatus(v1alpha1.StatusError)
 		r.RollingUpgrade.SetLabel(v1alpha1.LabelKeyRollingUpgradeCurrentStatus, v1alpha1.StatusError)
+		r.RollingUpgrade.Status.SetCondition(v1alpha1.RollingUpgradeCondition{
+			Type:   v1alpha1.UpgradeComplete,
+			Status: corev1.ConditionFalse,
+		})
 		common.SetMetricRollupFailed(r.RollingUpgrade.Name)
 
 		// uncordoning any nodes that were cordoned by early cordon feature
@@ -120,6 +124,14 @@ func (r *RollingUpgradeContext) RotateNodes() error {
 	if !r.IsScalingGroupDrifted() {
 		r.RollingUpgrade.SetCurrentStatus(v1alpha1.StatusComplete)
 		r.RollingUpgrade.SetLabel(v1alpha1.LabelKeyRollingUpgradeCurrentStatus, v1alpha1.StatusComplete)
+		// Surface the terminal state through conditions too so callers
+		// can `kubectl wait --for condition=Complete` on the resource
+		// (#321). Before this, only .status.currentStatus was set, so
+		// kubectl wait never saw a transition.
+		r.RollingUpgrade.Status.SetCondition(v1alpha1.RollingUpgradeCondition{
+			Type:   v1alpha1.UpgradeComplete,
+			Status: corev1.ConditionTrue,
+		})
 		common.SetMetricRollupCompleted(r.RollingUpgrade.Name)
 		r.endTimeUpdate()
 


### PR DESCRIPTION
## Description

The controller sets `.status.currentStatus` when a `RollingUpgrade` reaches a terminal state (success or failure) but never touches `.status.conditions`. That keeps `kubectl wait rollingupgrade/x --for condition=Complete` blocked until timeout even after the upgrade has already finished. The CRD already declares `Conditions []RollingUpgradeCondition` and `UpgradeComplete` as a type, so the plumbing exists, it's just not being written.

The reporter notes the behaviour regressed between 0.13 (conditions were set) and 1.0.4 (conditions are not).

Fixes #321.

## Change

- `controllers/upgrade.go`:
  - On the "scaling group is no longer drifted" branch (line ~121), in addition to `SetCurrentStatus(StatusComplete)`, emit `Status.SetCondition({Type: UpgradeComplete, Status: ConditionTrue})`.
  - On the `Cloud.Discover` failure branch, emit `Status.SetCondition({Type: UpgradeComplete, Status: ConditionFalse})`.
- `controllers/rollingupgrade_controller.go`:
  - On the `RotateNodes` failure branch (line ~227), emit the same `ConditionFalse` variant alongside the existing `SetCurrentStatus(StatusError)`.

`RollingUpgradeStatus.SetCondition` already upserts by type, so re-entry is a no-op.

## Testing

- `make test` passes locally.
- Manually exercised:
  - Successful rollout: `.status.conditions[?(@.type==\"Complete\")].status` now flips to `"True"` at completion; `kubectl wait --for condition=Complete` returns immediately.
  - Discover/RotateNodes failure: the same condition lands with `"False"`, so `--for condition=Complete=False` also works.

## Checklist

- [x] I've read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I've run `make test` locally and all tests pass
- [x] I've signed-off my commits with `git commit -s` for DCO verification
- [x] Code follows the style guidelines of this project