### PR TITLE
ci: bump golangci-lint to v2.13.2 for Go 1.27

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   GO_VERSION: stable
-  GOLANGCI_LINT_VERSION: v2.11.4
+  GOLANGCI_LINT_VERSION: v2.13.2
 
 jobs:
   detect-modules:


### PR DESCRIPTION
## Summary
- Bump `GOLANGCI_LINT_VERSION` from v2.11.4 to v2.13.2 so lint can load packages that require Go 1.27.
- Fixes the `golangci-lint` panic (`file requires newer Go version go1.27 (application built with go1.26)`) that is currently failing PRs such as #573.

## Test plan
- [ ] Confirm the golangci-lint workflow on this PR completes successfully
- [ ] Re-run or rebase #573 after this lands and confirm lint is no longer panicking
